### PR TITLE
feat: implement ExposeMap MVP

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+coverage
+.git
+.github
+.env
+.env.*
+npm-debug.log*
+*.log
+.DS_Store

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report incorrect behavior or an unexpected error
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Environment
+
+- OS:
+- Node.js version:
+- ExposeMap version or commit:
+- Docker version, if relevant:
+
+## Command Run
+
+```bash
+exposemap scan ./docker-compose.yml --format markdown
+```
+
+## Expected Behavior
+
+What did you expect ExposeMap to report?
+
+## Actual Behavior
+
+What happened instead?
+
+## Compose Snippet Without Secrets
+
+Please include the smallest sanitized Compose snippet that reproduces the issue.
+
+```yaml
+services:
+  app:
+    image: example/app
+```
+
+## Logs
+
+```text
+Paste relevant logs here.
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest an improvement for ExposeMap
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+What problem would this solve?
+
+## Proposed Solution
+
+What would you like ExposeMap to do?
+
+## Alternatives
+
+What alternatives or workarounds have you considered?
+
+## Example Compose Snippet, If Relevant
+
+Please remove secrets, private domains, credentials, and sensitive infrastructure details.
+
+```yaml
+services:
+  app:
+    image: example/app
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules/
+dist/
+coverage/
+.env
+.env.*
+!.env.example
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store
+Thumbs.db
+*.log
+.idea/
+.vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+## Project Purpose
+
+ExposeMap is a TypeScript CLI tool for self-hosted Docker Compose exposure mapping. It scans Compose configuration locally and reports whether services appear internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown.
+
+ExposeMap must stay read-only in the MVP. It must not modify `docker-compose.yml`, connect to containers, scan external networks, or add hosted/cloud functionality unless explicitly requested.
+
+## Code Style Rules
+
+- Keep code simple, readable, modular, and easy for open-source contributors to understand.
+- Put individual checks in `src/rules/`.
+- Put shared types in `src/types.ts`.
+- Put report rendering in `src/report/`.
+- Prefer small functions with clear names over clever abstractions.
+- Do not build a web dashboard unless explicitly requested.
+- Do not add real network scanning unless explicitly requested.
+- Do not add cloud/hosted functionality unless explicitly requested.
+- Do not add authentication unless explicitly requested.
+
+## Testing Rules
+
+- Use Vitest for tests.
+- Add or update focused tests for every behavior change.
+- Cover parser changes, rule changes, report rendering changes, and CLI behavior when practical.
+- Run `npm test` and `npm run build` before committing.
+
+## README Update Rules
+
+- Update `README.md` when CLI behavior, Docker usage, output formats, limitations, or roadmap items change.
+- Keep the README clear, technical, humble, and useful for self-hosters and GitHub visitors.
+- Do not claim ExposeMap proves real internet exposure.
+- Clearly state when behavior is based on heuristics.
+
+## Git Workflow Rules
+
+- Work on task branches, not directly on `main`.
+- Do not overwrite unrelated user changes.
+- Stage only relevant files.
+- Do not force push.
+- Do not commit generated build artifacts such as `dist/`, `coverage/`, or `node_modules/`.
+- End every task with branch, commit hash, push status, and PR link if available.
+
+## Security and Safety Rules
+
+- Do not commit secrets, `.env` files, private Compose files, credentials, tokens, or sensitive infrastructure details.
+- ExposeMap must run locally and must not send Compose files or reports anywhere.
+- ExposeMap must not perform real network scans in the MVP.
+- Treat findings as configuration-review heuristics, not proof of external reachability.
+- Do not ask users to paste private Compose files with secrets into public issues.
+
+## Verification Before Handoff
+
+- Run `npm test`.
+- Run `npm run build`.
+- Run the CLI against at least one example.
+- Build the Docker image when Docker changes or release readiness is requested.
+- Report branch, commit hash, push status, PR link if available, and any blocked checks or manual steps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to ExposeMap
+
+Thanks for considering a contribution. ExposeMap is intentionally small: a local TypeScript CLI that reviews Docker Compose configuration and prints exposure reports.
+
+## Install
+
+```bash
+npm install
+```
+
+## Run Tests
+
+```bash
+npm test
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+## Run the CLI Locally
+
+```bash
+npm run build
+node dist/cli.js scan examples/risky-compose.yml --format markdown
+```
+
+## Add a New Rule
+
+1. Add the rule implementation under `src/rules/`.
+2. Keep the rule read-only and based on Compose configuration.
+3. Add shared types to `src/types.ts` if needed.
+4. Wire the rule into `src/rules/serviceClassifier.ts`.
+5. Add focused Vitest coverage under `tests/`.
+6. Update `README.md` if the user-visible behavior changes.
+
+## Open an Issue or PR
+
+- Use a concise title.
+- Include the command you ran and the output you expected.
+- Include sanitized Compose snippets only.
+- Do not include secrets, tokens, private domains, credentials, private IP details, or sensitive infrastructure information.
+
+## Coding Style
+
+- Keep code readable and modular.
+- Prefer explicit rule names and clear evidence strings.
+- Avoid broad refactors in small PRs.
+- Do not add network scanning, hosted dashboards, authentication, or container connections unless the issue explicitly calls for it.
+- Run `npm test` and `npm run build` before opening a PR.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+FROM deps AS build
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+RUN npm prune --omit=dev
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/package*.json ./
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+ENTRYPOINT ["node", "/app/dist/cli.js"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,142 @@
+# ExposeMap
+
+Open-source exposure mapper for self-hosted Docker Compose services.
+
+ExposeMap scans `docker-compose.yml` files and produces a local Markdown report showing which services appear to be internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown.
+
+It is built for self-hosters, homelab users, small teams, and developers running Compose stacks on VPS, NAS, home servers, Tailscale, WireGuard, reverse proxies, or public cloud servers.
+
+## What ExposeMap Is
+
+ExposeMap is a lightweight, read-only configuration review tool. It parses Docker Compose files, applies simple exposure heuristics, and prints a report you can review or share with your team.
+
+ExposeMap runs locally. It does not send your Compose files, reports, service names, labels, or infrastructure details anywhere.
+
+## Why ExposeMap Exists
+
+Self-hosted stacks often grow one service at a time: a database here, an admin panel there, a reverse proxy in front, maybe a VPN or tunnel later. After enough changes, it becomes hard to answer a basic question:
+
+Which services are reachable, and how?
+
+ExposeMap helps make that first-pass map visible from the Compose configuration you already have.
+
+## What It Maps
+
+- Docker Compose services
+- Short syntax port mappings such as `80:80`, `5432:5432`, and `127.0.0.1:8080:8080`
+- Long syntax Compose ports using `target`, `published`, and `host_ip`
+- Localhost-only bindings
+- Broad/public host bindings
+- Likely reverse proxy services
+- Traefik routing labels and obvious reverse proxy hints
+- Risky directly exposed database, cache, search, and admin ports
+- A Mermaid diagram of likely exposure paths
+
+## Who It Is For
+
+- self-hosters
+- homelab users
+- small teams running Docker Compose
+- developers running apps on VPS, NAS, home servers, public cloud servers, Tailscale, WireGuard, or reverse proxies
+
+## Quick Start
+
+```bash
+npm install
+npm run build
+node dist/cli.js scan ./docker-compose.yml --format markdown
+```
+
+When installed as a package, the CLI command is:
+
+```bash
+exposemap scan ./docker-compose.yml --format markdown
+```
+
+## Run With Docker
+
+```bash
+docker build -t exposemap .
+docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format markdown
+```
+
+## Example Report
+
+```markdown
+# ExposeMap Report
+
+Scanned file: `examples/risky-compose.yml`
+
+Total services: 6
+
+## Exposure Summary
+
+| Service | Classification | Ports | Reverse proxy hints |
+| --- | --- | --- | --- |
+| traefik | directly exposed | `80:80`<br>`443:443` | proxy service |
+| web | reverse-proxy exposed | - | routing labels/env |
+| postgres | directly exposed | `5432:5432` | - |
+| redis | directly exposed | `0.0.0.0:6379:6379` | - |
+```
+
+See [examples/report.md](examples/report.md) for a generated sample.
+
+## Mermaid Diagram Example
+
+```mermaid
+graph TD
+  Internet[Internet]
+  Localhost[Localhost]
+  InternalNetwork[Internal network]
+  Internet --> svc_traefik[traefik]
+  svc_traefik --> svc_web[web]
+  Internet --> svc_postgres[postgres]
+  Internet --> svc_redis[redis]
+  Localhost --> svc_admin[admin]
+  InternalNetwork --> svc_worker[worker]
+  svc_web --> svc_postgres[postgres]
+  svc_web --> svc_redis[redis]
+```
+
+## Current Limitations
+
+- No real network scanning in the MVP
+- No Kubernetes support in the MVP
+- No Cloudflare Tunnel API integration in the MVP
+- No Tailscale API integration in the MVP
+- No hosted dashboard in the MVP
+- Findings are heuristic checks based on Docker Compose configuration
+- Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure
+
+ExposeMap does not prove real internet exposure. It does not replace a full security review, external exposure scan, firewall review, or threat model.
+
+## Roadmap
+
+- JSON report output
+- HTML report output
+- GitHub Actions integration
+- Better reverse proxy label support
+- Caddy config support
+- Nginx Proxy Manager support
+- Cloudflare Tunnel hints
+- Tailscale checklist
+- External scan integration, opt-in only
+- Hosted dashboard
+
+## Contributing
+
+Contributions are welcome. Good first areas include parser edge cases, reverse proxy hints, report output, docs, and sanitized Compose examples.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
+
+## Community
+
+For now, GitHub issues and discussions are the best place to share examples, edge cases, and ideas. Please do not paste private Compose files, secrets, credentials, or sensitive infrastructure details into public issues.
+
+## Hosted Version / Support Note
+
+Hosted dashboards, scheduled exposure checks, alerts, and setup reviews may come later. If you are interested, open an issue or contact the maintainer.
+
+## License
+
+ExposeMap is licensed under AGPLv3. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+ExposeMap is a local, read-only Docker Compose configuration review tool. It does not perform real network scans, connect to containers, modify Compose files, or send reports anywhere.
+
+ExposeMap is not a full security audit. Its findings are heuristics based on Compose configuration and should be reviewed alongside firewall rules, reverse proxy configuration, VPN setup, DNS, cloud security groups, and host-level settings.
+
+## Reporting Security Concerns
+
+Please report security concerns by contacting the maintainer through the GitHub profile. Do not post secrets, credentials, private compose files, or sensitive infrastructure details in public issues.
+
+## Handling Sensitive Data
+
+- Do not paste private Compose files into public issues.
+- Do not paste `.env` files, credentials, API keys, tokens, private domains, or internal hostnames.
+- If a Compose snippet is needed, reduce it to the smallest sanitized example that reproduces the issue.
+
+## Scope
+
+Security reports about ExposeMap itself are welcome, especially issues involving unsafe file handling, accidental data disclosure, dependency risks, or misleading output that could cause unsafe conclusions.

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -1,0 +1,60 @@
+# Launch Checklist
+
+## GitHub Readiness
+
+- README explains what ExposeMap is in the first screen.
+- Quick Start works from a clean clone.
+- Docker build and Docker run commands work.
+- Example report is committed.
+- LICENSE, CONTRIBUTING, SECURITY, and issue templates exist.
+- Roadmap issues are created or drafted.
+- No secrets, `.env` files, `node_modules`, `dist`, coverage, or OS junk are committed.
+
+## Reddit Account Readiness
+
+- Create the account ahead of launch.
+- Comment naturally in `r/selfhosted`.
+- Do not post the product during warm-up.
+- Do not paste links during warm-up.
+- Build some karma.
+- Target 2-4 weeks if possible.
+
+## Hacker News Readiness
+
+- Create an account ahead of launch.
+- Use a clear `Show HN` title.
+- Link to the GitHub repo.
+- Be available to answer technical questions.
+
+## Lemmy Readiness
+
+- Pick a relevant self-hosted or open-source community.
+- Read community rules before posting.
+- Keep the post short and technical.
+
+## Dev.to / Medium / Hackernoon Article Checklist
+
+- Explain the problem before mentioning ExposeMap.
+- Include concrete Compose examples.
+- Keep the tone useful and transparent.
+- Link to GitHub as the primary destination.
+- Do not claim ExposeMap proves real internet exposure.
+
+## Launch-week Schedule
+
+- Day 1: Publish GitHub repo and README.
+- Day 2: Post Show HN.
+- Day 3: Post to `r/selfhosted` if the account is ready.
+- Day 4: Post to Lemmy.
+- Day 5: Publish Dev.to article.
+- Day 6: Adapt and publish Medium/Hackernoon drafts.
+- Day 7: Review issues, summarize feedback, and update roadmap.
+
+## Post-launch Response Checklist
+
+- Reply calmly and technically.
+- Ask for sanitized examples, not private Compose files.
+- Turn repeated feedback into GitHub issues.
+- Label good first issues.
+- Fix broken Quick Start or Docker instructions quickly.
+- Document known limitations instead of overstating capabilities.

--- a/examples/report.md
+++ b/examples/report.md
@@ -1,0 +1,172 @@
+# ExposeMap Report
+
+Scanned file: `examples/risky-compose.yml`
+
+Total services: 6
+
+## Exposure Summary
+
+| Service | Classification | Ports | Reverse proxy hints |
+| --- | --- | --- | --- |
+| traefik | directly exposed | `80:80`<br>`443:443` | proxy service |
+| web | reverse-proxy exposed | - | routing labels/env |
+| postgres | directly exposed | `5432:5432` | - |
+| redis | directly exposed | `0.0.0.0:6379:6379` | - |
+| admin | localhost-only | `127.0.0.1:8080:8080` | - |
+| worker | internal | - | - |
+
+## High-risk Findings
+
+### PostgreSQL appears directly exposed
+
+- Severity: high
+- Service: `postgres`
+- Rule: `risky-direct-port`
+- Evidence: `5432:5432`
+- Recommendation: Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path.
+
+This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.
+
+### Redis appears directly exposed
+
+- Severity: high
+- Service: `redis`
+- Rule: `risky-direct-port`
+- Evidence: `0.0.0.0:6379:6379`
+- Recommendation: Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path.
+
+This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.
+
+## Service Details
+
+### traefik
+
+Classification: **directly exposed**
+
+Ports:
+
+- `80:80` (broad/public)
+- `443:443` (broad/public)
+
+Findings:
+
+No service-specific findings.
+
+### web
+
+Classification: **reverse-proxy exposed**
+
+Ports:
+
+- No Compose `ports` entries detected.
+
+Findings:
+
+No service-specific findings.
+
+### postgres
+
+Classification: **directly exposed**
+
+Ports:
+
+- `5432:5432` (broad/public)
+
+Findings:
+
+### PostgreSQL appears directly exposed
+
+- Severity: high
+- Service: `postgres`
+- Rule: `risky-direct-port`
+- Evidence: `5432:5432`
+- Recommendation: Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path.
+
+This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.
+
+### redis
+
+Classification: **directly exposed**
+
+Ports:
+
+- `0.0.0.0:6379:6379` (broad/public)
+
+Findings:
+
+### Redis appears directly exposed
+
+- Severity: high
+- Service: `redis`
+- Rule: `risky-direct-port`
+- Evidence: `0.0.0.0:6379:6379`
+- Recommendation: Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path.
+
+This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.
+
+### admin
+
+Classification: **localhost-only**
+
+Ports:
+
+- `127.0.0.1:8080:8080` (localhost-only)
+
+Findings:
+
+### Service is localhost-only
+
+- Severity: low
+- Service: `admin`
+- Rule: `localhost-only`
+- Evidence: `127.0.0.1:8080:8080`
+- Recommendation: Keep this pattern for admin tools and databases unless broader access is intentional.
+
+All parsed port mappings are bound to localhost.
+
+### worker
+
+Classification: **internal**
+
+Ports:
+
+- No Compose `ports` entries detected.
+
+Findings:
+
+### Service appears internal
+
+- Severity: low
+- Service: `worker`
+- Rule: `internal-service`
+- Evidence: `worker`
+- Recommendation: Confirm this matches the intended access path and document any VPN or proxy assumptions.
+
+No Compose port mappings or reverse proxy routing labels were detected.
+
+## Mermaid Diagram
+
+```mermaid
+graph TD
+  Internet[Internet]
+  Localhost[Localhost]
+  InternalNetwork[Internal network]
+  Internet --> svc_traefik[traefik]
+  svc_traefik --> svc_web[web]
+  Internet --> svc_postgres[postgres]
+  Internet --> svc_redis[redis]
+  Localhost --> svc_admin[admin]
+  InternalNetwork --> svc_worker[worker]
+  svc_web --> svc_postgres[postgres]
+  svc_web --> svc_redis[redis]
+  svc_worker --> svc_redis[redis]
+```
+
+## Limitations
+
+- ExposeMap is a lightweight, read-only configuration review tool.
+- Results are heuristic checks based on Docker Compose configuration.
+- ExposeMap does not prove real internet exposure.
+- ExposeMap does not perform real network scans.
+- ExposeMap does not connect to containers or modify Compose files.
+- Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure.

--- a/examples/risky-compose.yml
+++ b/examples/risky-compose.yml
@@ -1,0 +1,41 @@
+services:
+  traefik:
+    image: traefik:v3
+    command:
+      - --providers.docker=true
+      - --entrypoints.web.address=:80
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  web:
+    image: ghcr.io/example/web:latest
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.web.rule: Host(`app.example.test`)
+      traefik.http.services.web.loadbalancer.server.port: "3000"
+    depends_on:
+      - postgres
+      - redis
+
+  postgres:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7
+    ports:
+      - "0.0.0.0:6379:6379"
+
+  admin:
+    image: adminer:latest
+    ports:
+      - "127.0.0.1:8080:8080"
+
+  worker:
+    image: ghcr.io/example/worker:latest
+    depends_on:
+      - redis

--- a/examples/safe-compose.yml
+++ b/examples/safe-compose.yml
@@ -1,0 +1,26 @@
+services:
+  caddy:
+    image: caddy:2
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+
+  app:
+    image: ghcr.io/example/app:latest
+    labels:
+      caddy.host: app.example.test
+      caddy.reverse_proxy: "{{upstreams 3000}}"
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16
+    ports:
+      - "127.0.0.1:5432:5432"
+
+  redis:
+    image: redis:7
+    expose:
+      - "6379"

--- a/launch/account-setup.md
+++ b/launch/account-setup.md
@@ -1,0 +1,71 @@
+# Account Setup
+
+Prepare accounts before launch week and send all traffic to the GitHub repo:
+
+https://github.com/kozinkaihatusya/exposemap
+
+## Hacker News
+
+- Create an account ahead of launch.
+- Use a `Show HN` post.
+- Link directly to the GitHub repo.
+- Be ready to answer technical questions.
+
+## Reddit
+
+- Create an account ahead of launch.
+- Comment naturally in `r/selfhosted`.
+- Do not post the product yet.
+- Do not paste links during warm-up.
+- Build some karma.
+- Target 2-4 weeks if possible.
+- Launch with a humble technical post and link to GitHub.
+
+## Lemmy
+
+- Pick relevant self-hosted and open-source communities.
+- Read each community's rules.
+- Keep the post shorter than the Reddit version.
+- Link to GitHub.
+
+## Dev.to
+
+- Prepare the article draft.
+- Use practical examples before mentioning ExposeMap.
+- Link to GitHub at the beginning and end.
+
+## Medium
+
+- Adapt the Dev.to article for a broader technical audience.
+- Keep claims modest and explain limitations clearly.
+- Link to GitHub.
+
+## Hackernoon
+
+- Adapt the article with a stronger technical narrative.
+- Avoid sales language.
+- Link to GitHub.
+
+## X
+
+- Keep the post short.
+- Mention the core checks.
+- Link to GitHub.
+
+## LinkedIn
+
+- Use a slightly more polished tone.
+- Keep it technical.
+- Link to GitHub.
+
+## Newsletter
+
+- Send a short note during the same launch week.
+- Include the GitHub link, what the MVP does, and what feedback would be useful.
+
+## Cross-platform Timing
+
+- Launch in the same week.
+- Do not overpost the same text everywhere.
+- Send all traffic to the GitHub repo.
+- Convert repeated feedback into GitHub issues.

--- a/launch/devto-article.md
+++ b/launch/devto-article.md
@@ -1,0 +1,105 @@
+# How to see what your self-hosted Docker Compose stack exposes
+
+GitHub link: https://github.com/kozinkaihatusya/exposemap
+
+## Why exposure is hard to reason about in self-hosted stacks
+
+Self-hosted Docker Compose setups usually start simple. One app, one database, maybe a reverse proxy. Over time, the stack grows: admin panels, dashboards, caches, search backends, VPNs, tunnels, and old experiments that still have port mappings.
+
+At some point, it becomes hard to answer a basic question: which services are reachable, and how?
+
+Docker Compose makes this especially easy to lose track of because exposure can be implied by small details:
+
+- `5432:5432` publishes PostgreSQL broadly unless host-level controls say otherwise.
+- `127.0.0.1:5432:5432` is very different.
+- A service with no `ports` entry may still be routed by a reverse proxy.
+- A reverse proxy may expose only intended apps, or it may hide complexity in labels, mounted config, or external state.
+
+## Mistake 1: Directly exposing databases
+
+A common self-hosting mistake is leaving a database port mapped to the host:
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+```
+
+This does not automatically mean the database is reachable from the internet. Firewalls, cloud security groups, VPNs, and host configuration matter. But it is still a strong signal that the setup deserves review.
+
+For many setups, the safer default is to remove the host port mapping or bind it to localhost:
+
+```yaml
+ports:
+  - "127.0.0.1:5432:5432"
+```
+
+## Mistake 2: Confusing localhost-only with public bindings
+
+These two Compose snippets look similar, but they have very different intent:
+
+```yaml
+ports:
+  - "8080:8080"
+```
+
+```yaml
+ports:
+  - "127.0.0.1:8080:8080"
+```
+
+The first publishes a host port broadly. The second binds to localhost. That distinction is easy to miss during reviews, especially in larger files.
+
+## Mistake 3: Assuming reverse proxy means everything is safe
+
+Reverse proxies are useful, but the phrase "behind a reverse proxy" can hide a lot of assumptions.
+
+Some services are routed through Traefik labels. Some are configured through Caddyfiles or Nginx files mounted into a container. Some use Nginx Proxy Manager state that is not visible in Compose. Some are exposed directly and proxied at the same time.
+
+Compose alone cannot prove the real exposure path, but it can show useful hints and contradictions.
+
+## Mistake 4: Losing track of admin panels
+
+Admin tools often use ports such as `8080`, `9090`, or `3000`. Those ports are not always dangerous, but they are worth checking when they are broadly published.
+
+Examples include database UIs, monitoring dashboards, container dashboards, internal tools, and temporary debugging interfaces.
+
+## Mistake 5: Not documenting exposure paths
+
+Even when the setup is correct, it helps to document why:
+
+- Which service is intentionally public?
+- Which service is only reachable through localhost?
+- Which service is reachable through a VPN?
+- Which service is routed through a reverse proxy?
+- Which services should never be directly exposed?
+
+Small exposure maps reduce future confusion.
+
+## Why I built ExposeMap
+
+I built ExposeMap as a small open-source CLI for this first-pass review.
+
+It scans a `docker-compose.yml` file and classifies services as:
+
+- internal
+- localhost-only
+- directly exposed
+- reverse-proxy exposed
+- unknown
+
+It generates a Markdown report with:
+
+- a summary table
+- high-risk findings
+- service details
+- a Mermaid diagram
+- limitations
+
+It runs locally, does not modify Compose files, does not connect to containers, does not send reports anywhere, and does not perform real network scans.
+
+That last point matters: ExposeMap is not a full security audit and does not prove internet exposure. It is a lightweight configuration review tool based on Compose heuristics.
+
+GitHub: https://github.com/kozinkaihatusya/exposemap

--- a/launch/discord-setup.md
+++ b/launch/discord-setup.md
@@ -1,0 +1,21 @@
+# Discord Setup
+
+Server name: `SelfHostGuard`
+
+## Manual Setup Steps
+
+1. Create a Discord server named `SelfHostGuard`.
+2. Use a simple icon and description focused on self-hosted exposure review and open-source tooling.
+3. Create the channels below.
+4. Add a short rule: do not post secrets, credentials, private Compose files, private domains, or sensitive infrastructure details.
+5. Pin the GitHub repo link in `#exposemap`.
+
+## Channels
+
+- `#announcements` - Release notes, important updates, and launch posts.
+- `#general` - General self-hosting and exposure review discussion.
+- `#exposemap` - ExposeMap usage, roadmap, and examples.
+- `#support` - Help with installation, CLI usage, Docker usage, and reports.
+- `#feature-requests` - Ideas for new rules, outputs, integrations, and docs.
+- `#bugs` - Bug reports with sanitized examples only.
+- `#contributors` - Contributor coordination, issues, and PR discussion.

--- a/launch/hacker-news.md
+++ b/launch/hacker-news.md
@@ -1,0 +1,21 @@
+# Show HN: ExposeMap - open-source exposure mapper for Docker Compose services
+
+GitHub: https://github.com/kozinkaihatusya/exposemap
+
+I built ExposeMap, a small open-source CLI for self-hosters who run services with Docker Compose.
+
+It scans a `docker-compose.yml` file and classifies services as:
+
+- internal
+- localhost-only
+- directly exposed
+- reverse-proxy exposed
+- unknown
+
+It also generates a Markdown report and a Mermaid diagram so you can review the likely exposure paths in a Compose stack.
+
+The goal is not to prove real internet exposure. It does not perform network scans, connect to containers, or send files anywhere. It is a local configuration review tool based on Compose heuristics.
+
+The MVP currently handles common port mappings, localhost bindings, Traefik-style labels, likely reverse proxy services, and risky directly exposed database/admin ports.
+
+Feedback, edge cases, and sanitized Compose examples are welcome.

--- a/launch/hackernoon-article.md
+++ b/launch/hackernoon-article.md
@@ -1,0 +1,69 @@
+# How to see what your self-hosted Docker Compose stack exposes
+
+Docker Compose makes self-hosting approachable, but it also makes exposure drift easy.
+
+A stack may begin with a single app and a database. A few months later it has a reverse proxy, dashboards, admin tools, Redis, monitoring, a VPN, maybe a tunnel, and several old port mappings nobody remembers adding.
+
+The practical question is simple: what is reachable?
+
+## Direct database exposure
+
+This is one of the easiest mistakes to make:
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+```
+
+That Compose snippet does not prove public internet exposure. A firewall or cloud security group may block it. But it is a strong signal that the service should be reviewed.
+
+The same applies to ports commonly used by Redis, MySQL/MariaDB, MongoDB, Elasticsearch/OpenSearch, and admin panels.
+
+## Localhost-only bindings
+
+This:
+
+```yaml
+ports:
+  - "127.0.0.1:8080:8080"
+```
+
+is materially different from this:
+
+```yaml
+ports:
+  - "8080:8080"
+```
+
+That distinction gets buried quickly when a Compose file grows.
+
+## Reverse proxy assumptions
+
+A service may have no direct `ports` entry but still be reachable through Traefik labels, a Caddyfile, Nginx config, or Nginx Proxy Manager state. Compose can show some hints, but not every source of truth.
+
+That is why exposure mapping should be treated as documentation and review, not as a guarantee.
+
+## Documenting the path
+
+For each service, it helps to know whether it is:
+
+- internal
+- localhost-only
+- directly exposed
+- reverse-proxy exposed
+- unknown
+
+This simple classification can make future reviews much easier.
+
+## Why I built ExposeMap
+
+ExposeMap is an open-source CLI that scans `docker-compose.yml` and generates a Markdown exposure report with a Mermaid diagram.
+
+It runs locally, does not send Compose files anywhere, does not connect to containers, does not modify files, and does not perform real network scans.
+
+It is intentionally a first-pass configuration review tool, not a full security audit.
+
+GitHub: https://github.com/kozinkaihatusya/exposemap

--- a/launch/lemmy.md
+++ b/launch/lemmy.md
@@ -1,0 +1,11 @@
+# I built ExposeMap, an open-source exposure mapper for Docker Compose services
+
+GitHub: https://github.com/kozinkaihatusya/exposemap
+
+ExposeMap is a small local CLI for self-hosted Docker Compose stacks. It scans `docker-compose.yml` and classifies services as internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown.
+
+It generates a Markdown report and Mermaid diagram, and currently checks common port mappings, localhost bindings, Traefik-style labels, likely reverse proxy services, and risky directly exposed database/admin ports.
+
+It does not perform real network scans, connect to containers, modify Compose files, or send anything anywhere. It is a read-only configuration review tool based on Compose heuristics.
+
+Feedback and sanitized edge cases are welcome.

--- a/launch/linkedin-post.md
+++ b/launch/linkedin-post.md
@@ -1,0 +1,11 @@
+I built ExposeMap, an open-source CLI for reviewing exposure in self-hosted Docker Compose stacks.
+
+It scans a `docker-compose.yml` file and classifies services as internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown. The report includes a summary table, high-risk findings, service details, and a Mermaid diagram.
+
+The goal is intentionally modest: make Compose exposure easier to reason about before doing a deeper firewall, reverse proxy, VPN, or external exposure review.
+
+ExposeMap runs locally, does not connect to containers, does not modify Compose files, does not send reports anywhere, and does not perform real network scans.
+
+GitHub: https://github.com/kozinkaihatusya/exposemap
+
+Feedback and sanitized edge cases are welcome.

--- a/launch/medium-article.md
+++ b/launch/medium-article.md
@@ -1,0 +1,57 @@
+# How to see what your self-hosted Docker Compose stack exposes
+
+Self-hosted Docker Compose stacks often become difficult to reason about over time. A setup may start with one app and one database, then grow into a mix of admin panels, reverse proxies, caches, dashboards, VPNs, tunnels, and old experiments.
+
+Eventually, a simple question becomes surprisingly hard to answer: which services are reachable, and how?
+
+## Why exposure gets confusing
+
+Compose exposure often depends on small details. `5432:5432` and `127.0.0.1:5432:5432` are not equivalent. A service with no `ports` entry may still be routed through Traefik. A reverse proxy may rely on mounted config or external state that is not obvious from the Compose file alone.
+
+This does not mean Compose can prove real internet exposure. Firewalls, cloud security groups, DNS, VPNs, and host-level rules all matter. But Compose can still provide useful signals.
+
+## Directly exposing databases
+
+Database ports such as PostgreSQL `5432`, MySQL `3306`, Redis `6379`, MongoDB `27017`, and Elasticsearch/OpenSearch `9200` are worth reviewing carefully when they are published broadly.
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+```
+
+For many stacks, localhost-only binding or no host port mapping is a safer default.
+
+## Localhost-only is different from broad binding
+
+These are easy to confuse:
+
+```yaml
+ports:
+  - "8080:8080"
+```
+
+```yaml
+ports:
+  - "127.0.0.1:8080:8080"
+```
+
+The first publishes broadly. The second binds to localhost. In a large Compose file, this difference is easy to miss.
+
+## Reverse proxies still need review
+
+Reverse proxies are useful, but they are not magic. Traefik labels, Caddyfiles, Nginx Proxy Manager state, host firewall rules, and VPN routing can all affect the real exposure path.
+
+Compose can show hints, but it cannot replace a full review.
+
+## Why I built ExposeMap
+
+I built ExposeMap as a small open-source CLI for self-hosted Docker Compose stacks.
+
+It scans `docker-compose.yml` and classifies services as internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown. It generates a Markdown report and a Mermaid diagram so you can quickly see likely exposure paths.
+
+ExposeMap runs locally. It does not modify Compose files, connect to containers, send reports anywhere, or perform real network scans.
+
+GitHub: https://github.com/kozinkaihatusya/exposemap

--- a/launch/reddit-selfhosted.md
+++ b/launch/reddit-selfhosted.md
@@ -1,0 +1,28 @@
+# I built an open-source exposure mapper for self-hosted Docker Compose services
+
+GitHub: https://github.com/kozinkaihatusya/exposemap
+
+I built ExposeMap because I kept seeing the same problem in self-hosted stacks: after a few Compose files, reverse proxies, admin tools, databases, VPNs, and experiments, it becomes hard to quickly answer what is exposed and how.
+
+ExposeMap is a small open-source CLI that scans a `docker-compose.yml` file and classifies services as:
+
+- internal
+- localhost-only
+- directly exposed
+- reverse-proxy exposed
+- unknown
+
+It generates a Markdown report with a summary table, high-risk findings, service details, and a Mermaid diagram.
+
+It can run locally with Node.js or Docker:
+
+```bash
+docker build -t exposemap .
+docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format markdown
+```
+
+Important caveat: it does not perform real network scans and does not prove internet exposure. It is a read-only Compose configuration review tool. It does not connect to containers or send Compose files anywhere.
+
+The MVP checks common port mappings, localhost-only bindings, broad/public bindings, Traefik labels, likely reverse proxy services, and risky directly exposed ports like Postgres, Redis, MySQL, MongoDB, Elasticsearch, and common admin panels.
+
+I would appreciate feedback, edge cases, and sanitized Compose examples. If you find it useful, a GitHub star would help other self-hosters find it.

--- a/launch/x-post.md
+++ b/launch/x-post.md
@@ -1,0 +1,7 @@
+I built ExposeMap, an open-source CLI for self-hosted Docker Compose stacks.
+
+It scans docker-compose.yml and maps services as internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown.
+
+Markdown report + Mermaid diagram. Runs locally. No real network scans.
+
+https://github.com/kozinkaihatusya/exposemap

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1329 @@
+{
+  "name": "exposemap",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "exposemap",
+      "version": "0.1.0",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "commander": "^14.0.2",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "exposemap": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.1",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "exposemap",
+  "version": "0.1.0",
+  "description": "Open-source exposure mapper for self-hosted Docker Compose services",
+  "type": "module",
+  "bin": {
+    "exposemap": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "scan:example": "node dist/cli.js scan examples/risky-compose.yml --format markdown"
+  },
+  "keywords": [
+    "docker",
+    "docker-compose",
+    "self-hosted",
+    "security",
+    "homelab",
+    "exposure"
+  ],
+  "author": "",
+  "license": "AGPL-3.0-or-later",
+  "dependencies": {
+    "commander": "^14.0.2",
+    "yaml": "^2.8.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.8"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { scanComposeFileToMarkdown } from "./index.js";
+
+const program = new Command();
+
+program
+  .name("exposemap")
+  .description("Open-source exposure mapper for self-hosted Docker Compose services")
+  .version("0.1.0");
+
+program
+  .command("scan")
+  .argument("<compose-file>", "Path to docker-compose.yml")
+  .option("--format <format>", "Report format: markdown", "markdown")
+  .description("Scan a Docker Compose file and print an exposure report")
+  .action(async (composeFile: string, options: { format: string }) => {
+    if (options.format !== "markdown") {
+      console.error(`Unsupported format: ${options.format}. The MVP currently supports markdown only.`);
+      process.exitCode = 1;
+      return;
+    }
+
+    try {
+      const report = await scanComposeFileToMarkdown(composeFile);
+      process.stdout.write(report);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`ExposeMap failed: ${message}`);
+      process.exitCode = 1;
+    }
+  });
+
+program.parseAsync();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,20 @@
+import { parseComposeFile } from "./parser.js";
+import { analyzeProject } from "./rules/serviceClassifier.js";
+import { renderMarkdownReport } from "./report/markdown.js";
+import type { ExposureReport } from "./types.js";
+
+export async function scanComposeFile(filePath: string): Promise<ExposureReport> {
+  const project = await parseComposeFile(filePath);
+  return analyzeProject(project);
+}
+
+export async function scanComposeFileToMarkdown(filePath: string): Promise<string> {
+  const report = await scanComposeFile(filePath);
+  return renderMarkdownReport(report);
+}
+
+export * from "./types.js";
+export { parseComposeContent, parseComposeFile } from "./parser.js";
+export { analyzeProject, analyzeService } from "./rules/serviceClassifier.js";
+export { renderMarkdownReport } from "./report/markdown.js";
+export { renderMermaidDiagram } from "./report/mermaid.js";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+import { parse } from "yaml";
+import type { ComposeProject, ComposeService } from "./types.js";
+
+export async function parseComposeFile(filePath: string): Promise<ComposeProject> {
+  const content = await readFile(filePath, "utf8");
+  return parseComposeContent(content, filePath);
+}
+
+export function parseComposeContent(content: string, filePath = "<memory>"): ComposeProject {
+  const document = parse(content) as unknown;
+
+  if (!isRecord(document)) {
+    throw new Error("Compose file must contain a YAML object.");
+  }
+
+  if (!isRecord(document.services)) {
+    throw new Error("Compose file must contain a services object.");
+  }
+
+  const services: ComposeService[] = Object.entries(document.services).map(([name, value]) => {
+    if (!isRecord(value)) {
+      throw new Error(`Service '${name}' must be a YAML object.`);
+    }
+
+    return {
+      name,
+      image: typeof value.image === "string" ? value.image : undefined,
+      ports: Array.isArray(value.ports) ? value.ports : [],
+      labels: normalizeKeyValueList(value.labels),
+      environment: normalizeKeyValueList(value.environment),
+      dependsOn: normalizeDependsOn(value.depends_on),
+      raw: value
+    };
+  });
+
+  return { filePath, services };
+}
+
+function normalizeKeyValueList(value: unknown): Record<string, string> {
+  if (!value) {
+    return {};
+  }
+
+  if (Array.isArray(value)) {
+    return Object.fromEntries(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => {
+          const equalsIndex = item.indexOf("=");
+          if (equalsIndex === -1) {
+            return [item, ""];
+          }
+          return [item.slice(0, equalsIndex), item.slice(equalsIndex + 1)];
+        })
+    );
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, item == null ? "" : String(item)])
+    );
+  }
+
+  return {};
+}
+
+function normalizeDependsOn(value: unknown): string[] {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string");
+  }
+
+  if (isRecord(value)) {
+    return Object.keys(value);
+  }
+
+  return [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -1,0 +1,109 @@
+import type { ExposureReport, Finding, ServiceAnalysis } from "../types.js";
+
+export function renderMarkdownReport(report: ExposureReport): string {
+  const highRiskFindings = report.findings.filter((finding) => finding.severity === "high");
+
+  return [
+    "# ExposeMap Report",
+    "",
+    `Scanned file: \`${report.filePath}\``,
+    "",
+    `Total services: ${report.services.length}`,
+    "",
+    "## Exposure Summary",
+    "",
+    renderSummaryTable(report.services),
+    "",
+    "## High-risk Findings",
+    "",
+    renderFindings(highRiskFindings, "No high-risk findings detected from Compose configuration."),
+    "",
+    "## Service Details",
+    "",
+    report.services.map(renderServiceDetails).join("\n\n"),
+    "",
+    "## Mermaid Diagram",
+    "",
+    "```mermaid",
+    report.mermaid,
+    "```",
+    "",
+    "## Limitations",
+    "",
+    "- ExposeMap is a lightweight, read-only configuration review tool.",
+    "- Results are heuristic checks based on Docker Compose configuration.",
+    "- ExposeMap does not prove real internet exposure.",
+    "- ExposeMap does not perform real network scans.",
+    "- ExposeMap does not connect to containers or modify Compose files.",
+    "- Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure.",
+    ""
+  ].join("\n");
+}
+
+function renderSummaryTable(services: ServiceAnalysis[]): string {
+  return [
+    "| Service | Classification | Ports | Reverse proxy hints |",
+    "| --- | --- | --- | --- |",
+    ...services.map((service) => {
+      const ports = service.ports.map((port) => `\`${port.evidence}\``).join("<br>") || "-";
+      const reverseProxyHints = [
+        service.isReverseProxy ? "proxy service" : "",
+        service.hasReverseProxyRouting ? "routing labels/env" : ""
+      ]
+        .filter(Boolean)
+        .join(", ");
+
+      return `| ${service.service.name} | ${service.classification} | ${ports} | ${reverseProxyHints || "-"} |`;
+    })
+  ].join("\n");
+}
+
+function renderFindings(findings: Finding[], emptyMessage: string): string {
+  if (findings.length === 0) {
+    return emptyMessage;
+  }
+
+  return findings
+    .map(
+      (finding) => [
+        `### ${finding.title}`,
+        "",
+        `- Severity: ${finding.severity}`,
+        `- Service: \`${finding.service}\``,
+        `- Rule: \`${finding.ruleId}\``,
+        `- Evidence: \`${finding.evidence}\``,
+        `- Recommendation: ${finding.recommendation}`,
+        "",
+        finding.description
+      ].join("\n")
+    )
+    .join("\n\n");
+}
+
+function renderServiceDetails(service: ServiceAnalysis): string {
+  const findings = service.findings.length
+    ? renderFindings(service.findings, "")
+    : "No service-specific findings.";
+  const ports = service.ports.length
+    ? service.ports
+        .map((port) => {
+          const binding = port.isLocalhostBound ? "localhost-only" : "broad/public";
+          return `- \`${port.evidence}\` (${binding})`;
+        })
+        .join("\n")
+    : "- No Compose `ports` entries detected.";
+
+  return [
+    `### ${service.service.name}`,
+    "",
+    `Classification: **${service.classification}**`,
+    "",
+    "Ports:",
+    "",
+    ports,
+    "",
+    "Findings:",
+    "",
+    findings
+  ].join("\n");
+}

--- a/src/report/mermaid.ts
+++ b/src/report/mermaid.ts
@@ -1,0 +1,69 @@
+import type { ServiceAnalysis } from "../types.js";
+
+export function renderMermaidDiagram(services: ServiceAnalysis[]): string {
+  const lines = ["graph TD"];
+  const reverseProxies = services.filter((service) => service.isReverseProxy);
+  const routedServices = services.filter((service) => service.hasReverseProxyRouting && !service.isReverseProxy);
+  const directlyExposed = services.filter(
+    (service) => service.classification === "directly exposed" && !service.isReverseProxy
+  );
+  const internal = services.filter((service) => service.classification === "internal");
+  const localhostOnly = services.filter((service) => service.classification === "localhost-only");
+  const unknown = services.filter((service) => service.classification === "unknown");
+
+  lines.push("  Internet[Internet]");
+  lines.push("  Localhost[Localhost]");
+  lines.push("  InternalNetwork[Internal network]");
+
+  if (reverseProxies.length > 0) {
+    for (const proxy of reverseProxies) {
+      lines.push(`  Internet --> ${nodeId(proxy.service.name)}[${escapeLabel(proxy.service.name)}]`);
+    }
+
+    for (const proxy of reverseProxies) {
+      for (const service of routedServices) {
+        lines.push(`  ${nodeId(proxy.service.name)} --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
+      }
+    }
+  }
+
+  for (const service of directlyExposed) {
+    lines.push(`  Internet --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
+  }
+
+  for (const service of localhostOnly) {
+    lines.push(`  Localhost --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
+  }
+
+  for (const service of internal) {
+    lines.push(`  InternalNetwork --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
+  }
+
+  for (const service of unknown) {
+    lines.push(`  Unknown[Unknown exposure] -.-> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
+  }
+
+  addDependencyEdges(lines, services);
+
+  return Array.from(new Set(lines)).join("\n");
+}
+
+function addDependencyEdges(lines: string[], services: ServiceAnalysis[]): void {
+  const knownServices = new Set(services.map((service) => service.service.name));
+
+  for (const service of services) {
+    for (const dependency of service.service.dependsOn) {
+      if (knownServices.has(dependency)) {
+        lines.push(`  ${nodeId(service.service.name)} --> ${nodeId(dependency)}[${escapeLabel(dependency)}]`);
+      }
+    }
+  }
+}
+
+function nodeId(name: string): string {
+  return `svc_${name.replace(/[^a-zA-Z0-9_]/g, "_")}`;
+}
+
+function escapeLabel(label: string): string {
+  return label.replace(/"/g, "'");
+}

--- a/src/rules/directExposure.ts
+++ b/src/rules/directExposure.ts
@@ -1,0 +1,9 @@
+import type { PortMapping } from "../types.js";
+
+export function getBroadlyBoundPorts(ports: PortMapping[]): PortMapping[] {
+  return ports.filter((port) => port.isBroadlyBound);
+}
+
+export function hasDirectExposure(ports: PortMapping[]): boolean {
+  return getBroadlyBoundPorts(ports).length > 0;
+}

--- a/src/rules/localhostBindings.ts
+++ b/src/rules/localhostBindings.ts
@@ -1,0 +1,9 @@
+import type { PortMapping } from "../types.js";
+
+export function getLocalhostBindings(ports: PortMapping[]): PortMapping[] {
+  return ports.filter((port) => port.isLocalhostBound);
+}
+
+export function hasOnlyLocalhostBindings(ports: PortMapping[]): boolean {
+  return ports.length > 0 && ports.every((port) => port.isLocalhostBound);
+}

--- a/src/rules/ports.ts
+++ b/src/rules/ports.ts
@@ -1,0 +1,128 @@
+import type { PortMapping } from "../types.js";
+
+const LOCALHOST_BINDINGS = new Set(["127.0.0.1", "localhost", "::1"]);
+
+export function parsePortMapping(raw: unknown): PortMapping | null {
+  if (typeof raw === "number") {
+    return buildPortMapping({
+      syntax: "short",
+      raw,
+      evidence: String(raw),
+      target: String(raw),
+      isPublished: true
+    });
+  }
+
+  if (typeof raw === "string") {
+    return parseShortPort(raw);
+  }
+
+  if (isRecord(raw)) {
+    return parseLongPort(raw);
+  }
+
+  return null;
+}
+
+export function parsePortMappings(rawPorts: unknown[]): PortMapping[] {
+  return rawPorts.map(parsePortMapping).filter((port): port is PortMapping => port !== null);
+}
+
+export function isLocalhostBinding(hostIp: string | undefined): boolean {
+  return hostIp ? LOCALHOST_BINDINGS.has(hostIp.toLowerCase()) : false;
+}
+
+function parseShortPort(raw: string): PortMapping | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const [withoutProtocol, protocol] = splitProtocol(trimmed);
+  const parts = withoutProtocol.split(":");
+
+  if (parts.length === 1) {
+    return buildPortMapping({
+      syntax: "short",
+      raw,
+      evidence: raw,
+      target: parts[0],
+      protocol,
+      isPublished: true
+    });
+  }
+
+  if (parts.length === 2) {
+    return buildPortMapping({
+      syntax: "short",
+      raw,
+      evidence: raw,
+      published: parts[0],
+      target: parts[1],
+      protocol,
+      isPublished: true
+    });
+  }
+
+  const [hostIp, published, ...targetParts] = parts;
+  return buildPortMapping({
+    syntax: "short",
+    raw,
+    evidence: raw,
+    hostIp,
+    published,
+    target: targetParts.join(":"),
+    protocol,
+    isPublished: true
+  });
+}
+
+function parseLongPort(raw: Record<string, unknown>): PortMapping | null {
+  const target = stringifyPort(raw.target);
+  const published = stringifyPort(raw.published);
+  const hostIp = typeof raw.host_ip === "string" ? raw.host_ip : undefined;
+  const protocol = typeof raw.protocol === "string" ? raw.protocol : undefined;
+
+  if (!target && !published) {
+    return null;
+  }
+
+  return buildPortMapping({
+    syntax: "long",
+    raw,
+    evidence: JSON.stringify(raw),
+    hostIp,
+    published,
+    target,
+    protocol,
+    isPublished: true
+  });
+}
+
+function buildPortMapping(input: Omit<PortMapping, "isLocalhostBound" | "isBroadlyBound">): PortMapping {
+  const isLocalhostBound = isLocalhostBinding(input.hostIp);
+  return {
+    ...input,
+    isLocalhostBound,
+    isBroadlyBound: input.isPublished && !isLocalhostBound
+  };
+}
+
+function splitProtocol(value: string): [string, string | undefined] {
+  const slashIndex = value.lastIndexOf("/");
+  if (slashIndex === -1) {
+    return [value, undefined];
+  }
+  return [value.slice(0, slashIndex), value.slice(slashIndex + 1)];
+}
+
+function stringifyPort(value: unknown): string | undefined {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/rules/reverseProxy.ts
+++ b/src/rules/reverseProxy.ts
@@ -1,0 +1,62 @@
+import type { ComposeService } from "../types.js";
+
+const REVERSE_PROXY_KEYWORDS = [
+  "traefik",
+  "caddy",
+  "nginx",
+  "nginx-proxy-manager",
+  "haproxy",
+  "swag",
+  "letsencrypt"
+];
+
+const ROUTING_ENV_HINTS = ["VIRTUAL_HOST", "LETSENCRYPT_HOST", "CADDY_HOST"];
+
+export function isLikelyReverseProxyService(service: ComposeService): boolean {
+  const haystack = `${service.name} ${service.image ?? ""}`.toLowerCase();
+
+  if (REVERSE_PROXY_KEYWORDS.some((keyword) => haystack.includes(keyword))) {
+    return true;
+  }
+
+  return tokenize(haystack).includes("npm");
+}
+
+export function hasReverseProxyRoutingHint(service: ComposeService): boolean {
+  return hasTraefikRoutingHint(service.labels) || hasCaddyLikeHint(service.labels) || hasEnvironmentRoutingHint(service.environment);
+}
+
+export function hasTraefikRoutingHint(labels: Record<string, string>): boolean {
+  return Object.entries(labels).some(([key, value]) => {
+    const normalizedKey = key.toLowerCase();
+    const normalizedValue = value.toLowerCase();
+
+    if (normalizedKey === "traefik.enable") {
+      return normalizedValue === "true";
+    }
+
+    return (
+      normalizedKey.startsWith("traefik.http.routers.") ||
+      normalizedKey.startsWith("traefik.http.services.") ||
+      normalizedKey.startsWith("traefik.http.middlewares.")
+    );
+  });
+}
+
+function hasCaddyLikeHint(labels: Record<string, string>): boolean {
+  return Object.entries(labels).some(([key, value]) => {
+    const entry = `${key}=${value}`.toLowerCase();
+    return entry.includes("caddy") && (entry.includes("host") || entry.includes("reverse_proxy"));
+  });
+}
+
+function hasEnvironmentRoutingHint(environment: Record<string, string>): boolean {
+  return ROUTING_ENV_HINTS.some((key) => {
+    const value = environment[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
+function tokenize(value: string): string[] {
+  return value.split(/[^a-z0-9]+/).filter(Boolean);
+}

--- a/src/rules/riskyServices.ts
+++ b/src/rules/riskyServices.ts
@@ -1,0 +1,41 @@
+import type { Finding, PortMapping } from "../types.js";
+
+interface RiskyPort {
+  name: string;
+  ports: string[];
+}
+
+const RISKY_PORTS: RiskyPort[] = [
+  { name: "PostgreSQL", ports: ["5432"] },
+  { name: "MySQL/MariaDB", ports: ["3306"] },
+  { name: "Redis", ports: ["6379"] },
+  { name: "MongoDB", ports: ["27017"] },
+  { name: "Elasticsearch/OpenSearch", ports: ["9200"] },
+  { name: "Admin or web panel", ports: ["8080", "9090", "3000"] }
+];
+
+export function findRiskyDirectExposure(serviceName: string, broadPorts: PortMapping[]): Finding[] {
+  return broadPorts.flatMap((port) => {
+    const matched = RISKY_PORTS.find((risk) => {
+      return risk.ports.some((riskPort) => port.target === riskPort || port.published === riskPort);
+    });
+
+    if (!matched) {
+      return [];
+    }
+
+    return [
+      {
+        ruleId: "risky-direct-port",
+        severity: "high",
+        service: serviceName,
+        title: `${matched.name} appears directly exposed`,
+        description:
+          "This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.",
+        evidence: port.evidence,
+        recommendation:
+          "Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path."
+      }
+    ];
+  });
+}

--- a/src/rules/serviceClassifier.ts
+++ b/src/rules/serviceClassifier.ts
@@ -1,0 +1,176 @@
+import type {
+  ComposeProject,
+  ComposeService,
+  ExposureClassification,
+  ExposureReport,
+  Finding,
+  ServiceAnalysis
+} from "../types.js";
+import { getBroadlyBoundPorts } from "./directExposure.js";
+import { getLocalhostBindings } from "./localhostBindings.js";
+import { parsePortMappings } from "./ports.js";
+import { hasReverseProxyRoutingHint, isLikelyReverseProxyService } from "./reverseProxy.js";
+import { findRiskyDirectExposure } from "./riskyServices.js";
+import { renderMermaidDiagram } from "../report/mermaid.js";
+
+export function analyzeProject(project: ComposeProject): ExposureReport {
+  const analyses = project.services.map(analyzeService);
+  const findings = analyses.flatMap((service) => service.findings);
+
+  addReverseProxyClarityFindings(analyses, findings);
+
+  return {
+    filePath: project.filePath,
+    services: analyses,
+    findings,
+    generatedAt: new Date().toISOString(),
+    mermaid: renderMermaidDiagram(analyses)
+  };
+}
+
+export function analyzeService(service: ComposeService): ServiceAnalysis {
+  const ports = parsePortMappings(service.ports);
+  const broadPorts = getBroadlyBoundPorts(ports);
+  const localhostPorts = getLocalhostBindings(ports);
+  const isReverseProxy = isLikelyReverseProxyService(service);
+  const hasReverseProxyRouting = hasReverseProxyRoutingHint(service);
+  const notes: string[] = [];
+  const classification = classifyService({
+    ports,
+    broadPorts,
+    localhostPorts,
+    hasReverseProxyRouting,
+    service
+  });
+
+  const findings: Finding[] = [
+    ...findRiskyDirectExposure(service.name, broadPorts),
+    ...buildInformationalFindings(service.name, classification, localhostPorts)
+  ];
+
+  if (ports.length !== service.ports.length) {
+    findings.push({
+      ruleId: "unknown-port-syntax",
+      severity: "medium",
+      service: service.name,
+      title: "Service exposure is unknown",
+      description: "At least one port entry could not be parsed by ExposeMap.",
+      evidence: JSON.stringify(service.ports),
+      recommendation: "Review this service manually and consider opening an issue with a sanitized Compose snippet."
+    });
+    notes.push("One or more port mappings could not be parsed.");
+  }
+
+  return {
+    service,
+    classification,
+    ports,
+    broadPorts,
+    localhostPorts,
+    isReverseProxy,
+    hasReverseProxyRouting,
+    findings,
+    notes
+  };
+}
+
+function classifyService(input: {
+  ports: ReturnType<typeof parsePortMappings>;
+  broadPorts: ReturnType<typeof getBroadlyBoundPorts>;
+  localhostPorts: ReturnType<typeof getLocalhostBindings>;
+  hasReverseProxyRouting: boolean;
+  service: ComposeService;
+}): ExposureClassification {
+  if (input.service.ports.length > 0 && input.ports.length !== input.service.ports.length) {
+    return "unknown";
+  }
+
+  if (input.broadPorts.length > 0) {
+    return "directly exposed";
+  }
+
+  if (input.ports.length > 0 && input.localhostPorts.length === input.ports.length) {
+    return "localhost-only";
+  }
+
+  if (input.hasReverseProxyRouting) {
+    return "reverse-proxy exposed";
+  }
+
+  if (input.ports.length === 0 && !input.hasReverseProxyRouting) {
+    return "internal";
+  }
+
+  return "unknown";
+}
+
+function buildInformationalFindings(
+  serviceName: string,
+  classification: ExposureClassification,
+  localhostPorts: ReturnType<typeof getLocalhostBindings>
+): Finding[] {
+  if (classification === "unknown") {
+    return [
+      {
+        ruleId: "unknown-exposure",
+        severity: "medium",
+        service: serviceName,
+        title: "Service exposure is unknown",
+        description: "ExposeMap could not confidently classify this service from Compose configuration alone.",
+        evidence: serviceName,
+        recommendation: "Review this service manually, including reverse proxy, VPN, firewall, and host-level configuration."
+      }
+    ];
+  }
+
+  if (classification === "localhost-only") {
+    return [
+      {
+        ruleId: "localhost-only",
+        severity: "low",
+        service: serviceName,
+        title: "Service is localhost-only",
+        description: "All parsed port mappings are bound to localhost.",
+        evidence: localhostPorts.map((port) => port.evidence).join(", "),
+        recommendation: "Keep this pattern for admin tools and databases unless broader access is intentional."
+      }
+    ];
+  }
+
+  if (classification === "internal") {
+    return [
+      {
+        ruleId: "internal-service",
+        severity: "low",
+        service: serviceName,
+        title: "Service appears internal",
+        description: "No Compose port mappings or reverse proxy routing labels were detected.",
+        evidence: serviceName,
+        recommendation: "Confirm this matches the intended access path and document any VPN or proxy assumptions."
+      }
+    ];
+  }
+
+  return [];
+}
+
+function addReverseProxyClarityFindings(analyses: ServiceAnalysis[], findings: Finding[]): void {
+  const reverseProxies = analyses.filter((service) => service.isReverseProxy);
+  const routedServices = analyses.filter((service) => service.hasReverseProxyRouting);
+
+  if (reverseProxies.length > 0 && routedServices.length === 0) {
+    for (const reverseProxy of reverseProxies) {
+      findings.push({
+        ruleId: "reverse-proxy-routes-unclear",
+        severity: "medium",
+        service: reverseProxy.service.name,
+        title: "Reverse proxy service detected but routed services are unclear",
+        description:
+          "A likely reverse proxy service exists, but ExposeMap did not find obvious routing labels on application services.",
+        evidence: reverseProxy.service.image ?? reverseProxy.service.name,
+        recommendation:
+          "Review reverse proxy configuration outside Compose, such as mounted Caddyfiles, Nginx Proxy Manager state, Traefik dynamic config, or host files."
+      });
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,68 @@
+export type ExposureClassification =
+  | "internal"
+  | "localhost-only"
+  | "directly exposed"
+  | "reverse-proxy exposed"
+  | "unknown";
+
+export type Severity = "high" | "medium" | "low";
+
+export type PortSyntax = "short" | "long";
+
+export interface PortMapping {
+  syntax: PortSyntax;
+  raw: unknown;
+  evidence: string;
+  hostIp?: string;
+  published?: string;
+  target?: string;
+  protocol?: string;
+  isPublished: boolean;
+  isLocalhostBound: boolean;
+  isBroadlyBound: boolean;
+}
+
+export interface ComposeService {
+  name: string;
+  image?: string;
+  ports: unknown[];
+  labels: Record<string, string>;
+  environment: Record<string, string>;
+  dependsOn: string[];
+  raw: Record<string, unknown>;
+}
+
+export interface ComposeProject {
+  filePath: string;
+  services: ComposeService[];
+}
+
+export interface Finding {
+  ruleId: string;
+  severity: Severity;
+  service: string;
+  title: string;
+  description: string;
+  evidence: string;
+  recommendation: string;
+}
+
+export interface ServiceAnalysis {
+  service: ComposeService;
+  classification: ExposureClassification;
+  ports: PortMapping[];
+  broadPorts: PortMapping[];
+  localhostPorts: PortMapping[];
+  isReverseProxy: boolean;
+  hasReverseProxyRouting: boolean;
+  findings: Finding[];
+  notes: string[];
+}
+
+export interface ExposureReport {
+  filePath: string;
+  services: ServiceAnalysis[];
+  findings: Finding[];
+  generatedAt: string;
+  mermaid: string;
+}

--- a/tests/directExposure.test.ts
+++ b/tests/directExposure.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getBroadlyBoundPorts, hasDirectExposure } from "../src/rules/directExposure.js";
+import { parsePortMappings } from "../src/rules/ports.js";
+
+describe("direct exposure detection", () => {
+  it("detects broad short syntax", () => {
+    const ports = parsePortMappings(["443:443"]);
+
+    expect(hasDirectExposure(ports)).toBe(true);
+    expect(getBroadlyBoundPorts(ports)).toHaveLength(1);
+  });
+
+  it("detects explicit 0.0.0.0 bindings as broad", () => {
+    const ports = parsePortMappings(["0.0.0.0:6379:6379"]);
+
+    expect(hasDirectExposure(ports)).toBe(true);
+  });
+
+  it("does not flag localhost-only bindings", () => {
+    const ports = parsePortMappings(["127.0.0.1:5432:5432"]);
+
+    expect(hasDirectExposure(ports)).toBe(false);
+  });
+});

--- a/tests/localhostBindings.test.ts
+++ b/tests/localhostBindings.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getLocalhostBindings, hasOnlyLocalhostBindings } from "../src/rules/localhostBindings.js";
+import { parsePortMappings } from "../src/rules/ports.js";
+
+describe("localhost binding detection", () => {
+  it("detects localhost-only services", () => {
+    const ports = parsePortMappings(["127.0.0.1:8080:8080", "localhost:3000:3000"]);
+
+    expect(getLocalhostBindings(ports)).toHaveLength(2);
+    expect(hasOnlyLocalhostBindings(ports)).toBe(true);
+  });
+
+  it("does not treat broad bindings as localhost-only", () => {
+    const ports = parsePortMappings(["127.0.0.1:8080:8080", "80:80"]);
+
+    expect(hasOnlyLocalhostBindings(ports)).toBe(false);
+  });
+});

--- a/tests/mermaid.test.ts
+++ b/tests/mermaid.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { parseComposeContent } from "../src/parser.js";
+import { analyzeProject } from "../src/rules/serviceClassifier.js";
+
+describe("Mermaid diagram generation", () => {
+  it("renders internet, reverse proxy, routed service, and dependencies", () => {
+    const project = parseComposeContent(`
+services:
+  traefik:
+    image: traefik:v3
+    ports:
+      - "80:80"
+  web:
+    image: web
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.web.rule: Host(\`web.example.test\`)
+    depends_on:
+      - db
+  db:
+    image: postgres
+`);
+
+    const report = analyzeProject(project);
+
+    expect(report.mermaid).toContain("graph TD");
+    expect(report.mermaid).toContain("Internet --> svc_traefik");
+    expect(report.mermaid).toContain("svc_traefik --> svc_web");
+    expect(report.mermaid).toContain("svc_web --> svc_db");
+  });
+});

--- a/tests/ports.test.ts
+++ b/tests/ports.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { parsePortMapping } from "../src/rules/ports.js";
+
+describe("parsePortMapping", () => {
+  it("parses broad short syntax", () => {
+    const port = parsePortMapping("80:80");
+
+    expect(port).toMatchObject({
+      published: "80",
+      target: "80",
+      isLocalhostBound: false,
+      isBroadlyBound: true
+    });
+  });
+
+  it("parses localhost short syntax", () => {
+    const port = parsePortMapping("127.0.0.1:8080:8080");
+
+    expect(port).toMatchObject({
+      hostIp: "127.0.0.1",
+      published: "8080",
+      target: "8080",
+      isLocalhostBound: true,
+      isBroadlyBound: false
+    });
+  });
+
+  it("parses localhost host name short syntax", () => {
+    const port = parsePortMapping("localhost:3000:3000");
+
+    expect(port).toMatchObject({
+      hostIp: "localhost",
+      isLocalhostBound: true,
+      isBroadlyBound: false
+    });
+  });
+
+  it("parses long syntax with host_ip", () => {
+    const port = parsePortMapping({
+      target: 5432,
+      published: 5432,
+      host_ip: "127.0.0.1",
+      protocol: "tcp"
+    });
+
+    expect(port).toMatchObject({
+      syntax: "long",
+      target: "5432",
+      published: "5432",
+      hostIp: "127.0.0.1",
+      protocol: "tcp",
+      isLocalhostBound: true
+    });
+  });
+});

--- a/tests/reverseProxy.test.ts
+++ b/tests/reverseProxy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { hasReverseProxyRoutingHint, isLikelyReverseProxyService } from "../src/rules/reverseProxy.js";
+import type { ComposeService } from "../src/types.js";
+
+describe("reverse proxy detection", () => {
+  it("detects likely reverse proxy services by image", () => {
+    expect(isLikelyReverseProxyService(service({ name: "proxy", image: "traefik:v3" }))).toBe(true);
+    expect(isLikelyReverseProxyService(service({ name: "caddy", image: "caddy:2" }))).toBe(true);
+  });
+
+  it("detects Traefik routing labels", () => {
+    expect(
+      hasReverseProxyRoutingHint(
+        service({
+          labels: {
+            "traefik.enable": "true",
+            "traefik.http.routers.app.rule": "Host(`app.example.test`)"
+          }
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("detects environment routing hints", () => {
+    expect(
+      hasReverseProxyRoutingHint(
+        service({
+          environment: {
+            VIRTUAL_HOST: "app.example.test"
+          }
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+function service(input: Partial<ComposeService>): ComposeService {
+  return {
+    name: "app",
+    ports: [],
+    labels: {},
+    environment: {},
+    dependsOn: [],
+    raw: {},
+    ...input
+  };
+}

--- a/tests/riskyServices.test.ts
+++ b/tests/riskyServices.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { findRiskyDirectExposure } from "../src/rules/riskyServices.js";
+import { parsePortMappings } from "../src/rules/ports.js";
+import { getBroadlyBoundPorts } from "../src/rules/directExposure.js";
+
+describe("risky direct exposure detection", () => {
+  it("flags directly exposed PostgreSQL", () => {
+    const ports = getBroadlyBoundPorts(parsePortMappings(["5432:5432"]));
+    const findings = findRiskyDirectExposure("db", ports);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      severity: "high",
+      title: "PostgreSQL appears directly exposed"
+    });
+  });
+
+  it("flags directly exposed admin ports", () => {
+    const ports = getBroadlyBoundPorts(parsePortMappings(["8080:8080"]));
+    const findings = findRiskyDirectExposure("admin", ports);
+
+    expect(findings[0]?.title).toContain("Admin");
+  });
+
+  it("does not flag localhost-only Redis", () => {
+    const ports = getBroadlyBoundPorts(parsePortMappings(["127.0.0.1:6379:6379"]));
+    const findings = findRiskyDirectExposure("redis", ports);
+
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/tests/serviceClassifier.test.ts
+++ b/tests/serviceClassifier.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseComposeContent } from "../src/parser.js";
+import { analyzeProject } from "../src/rules/serviceClassifier.js";
+
+describe("service classification", () => {
+  it("classifies internal, localhost-only, directly exposed, and reverse-proxy exposed services", () => {
+    const project = parseComposeContent(`
+services:
+  web:
+    image: nginx
+    ports:
+      - "80:80"
+  admin:
+    image: adminer
+    ports:
+      - "127.0.0.1:8080:8080"
+  app:
+    image: app
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.app.rule: Host(\`app.example.test\`)
+  worker:
+    image: worker
+`);
+
+    const report = analyzeProject(project);
+    const classifications = Object.fromEntries(
+      report.services.map((service) => [service.service.name, service.classification])
+    );
+
+    expect(classifications).toEqual({
+      web: "directly exposed",
+      admin: "localhost-only",
+      app: "reverse-proxy exposed",
+      worker: "internal"
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "tests"]
+}


### PR DESCRIPTION
## Summary
- Implements ExposeMap as a TypeScript CLI for read-only Docker Compose exposure mapping.
- Adds Compose parsing, service classification, risky direct exposure findings, Markdown reporting, and Mermaid diagram output.
- Adds Docker support, examples, tests, OSS support docs, and launch materials.

## MVP verification
- Parses Docker Compose services and ports.
- Classifies services as internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown.
- Detects localhost bindings, broad bindings, Traefik-style routing hints, likely reverse proxy services, and risky database/admin ports.
- Generates Markdown report with summary, high-risk findings, service details, Mermaid diagram, and limitations.

## Files changed
- CLI and library code under `src/`.
- Rules under `src/rules/`.
- Report renderers under `src/report/`.
- Vitest tests under `tests/`.
- Examples under `examples/`.
- Docs and launch materials under `docs/` and `launch/`.
- Docker, README, AGENTS, CONTRIBUTING, SECURITY, issue templates, package metadata, and AGPLv3 license.

## Tests run
- `npm install`
- `npm test`
- `npm run build`
- `node dist/cli.js scan examples/risky-compose.yml --format markdown > examples/report.md`
- `npm audit --audit-level=high`

## Docker command tested
- `docker build -t exposemap .`
- `docker run --rm -v $(pwd):/scan exposemap scan /scan/examples/risky-compose.yml --format markdown`

## Launch materials added
- Hacker News, Reddit, Lemmy, X, LinkedIn, Dev.to, Medium, Hackernoon drafts.
- Discord setup and account setup notes.
- Launch checklist.

## Current limitations
- Heuristic Compose-based checks only.
- No real network scanning.
- No Kubernetes support.
- No Cloudflare Tunnel API integration.
- No Tailscale API integration.
- No hosted dashboard.

## Notes
The repository was initially empty, so `main` was created with an empty initial commit and this feature branch was merged with that base without rewriting pushed history.