### PR TITLE
feat: add JSON output and CI fail thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Open-source exposure mapper for self-hosted Docker Compose services.
 
-ExposeMap scans `docker-compose.yml` files and produces a local Markdown report showing which services appear to be internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown.
+ExposeMap scans `docker-compose.yml` files and produces local Markdown or JSON reports showing which services appear to be internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown.
 
 It is built for self-hosters, homelab users, small teams, and developers running Compose stacks on VPS, NAS, home servers, Tailscale, WireGuard, reverse proxies, or public cloud servers.
 
@@ -31,6 +31,7 @@ ExposeMap helps make that first-pass map visible from the Compose configuration 
 - Traefik routing labels and obvious reverse proxy hints
 - Risky directly exposed database, cache, search, and admin ports
 - A Mermaid diagram of likely exposure paths
+- Markdown and JSON reports for local review or CI usage
 
 ## Who It Is For
 
@@ -53,12 +54,90 @@ When installed as a package, the CLI command is:
 exposemap scan ./docker-compose.yml --format markdown
 ```
 
+Markdown remains the default output:
+
+```bash
+exposemap scan ./docker-compose.yml
+```
+
+## JSON Output
+
+Use JSON when you want CI-friendly structured output:
+
+```bash
+exposemap scan ./docker-compose.yml --format json
+```
+
+The JSON report includes tool metadata, scanned file path, generated timestamp, summary counts, services, exposure map entries, findings, and the Mermaid diagram string.
+
+## Fail-on Thresholds
+
+Use `--fail-on` to make ExposeMap return exit code `1` when findings at or above a chosen severity are present:
+
+```bash
+exposemap scan ./docker-compose.yml --fail-on high
+exposemap scan ./docker-compose.yml --format json --fail-on medium
+```
+
+Supported values:
+
+- `none` - always exit `0` unless CLI usage or parsing fails
+- `high` - exit `1` if any high finding exists
+- `medium` - exit `1` if any medium or high finding exists
+- `low` - exit `1` if any low, medium, or high finding exists
+
+The default is `none` for backward compatibility.
+
+## Exit Codes
+
+- `0` - scan completed and the `--fail-on` threshold was not violated
+- `1` - scan completed and the `--fail-on` threshold was violated
+- `2` - invalid CLI usage, unsupported options, missing files, or Compose parsing errors
+
 ## Run With Docker
 
 ```bash
 docker build -t exposemap .
 docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format markdown
 ```
+
+Docker with JSON and CI threshold:
+
+```bash
+docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format json --fail-on high
+```
+
+## CI Usage
+
+ExposeMap can run in CI as a lightweight Compose-based exposure review step. It runs locally in the job, does not send `docker-compose.yml` files or reports anywhere, and does not perform real network scans.
+
+See [docs/ci-usage.md](docs/ci-usage.md) for local, Docker, JSON, and `--fail-on` examples.
+
+Example GitHub Actions workflow:
+
+```yaml
+name: ExposeMap
+
+on:
+  pull_request:
+    paths:
+      - "**/docker-compose*.yml"
+      - "**/compose*.yml"
+
+jobs:
+  exposemap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm run build
+      - run: node dist/cli.js scan examples/risky-compose.yml --format json --fail-on high
+```
+
+The full example is available at [docs/github-actions-example.yml](docs/github-actions-example.yml). The example uses `examples/risky-compose.yml`, so the `--fail-on high` step is expected to fail; replace the path with your own Compose file in real CI.
 
 ## Example Report
 
@@ -100,11 +179,11 @@ graph TD
 
 ## Current Limitations
 
-- No real network scanning in the MVP
-- No Kubernetes support in the MVP
-- No Cloudflare Tunnel API integration in the MVP
-- No Tailscale API integration in the MVP
-- No hosted dashboard in the MVP
+- No real network scanning
+- No Kubernetes support
+- No Cloudflare Tunnel API integration
+- No Tailscale API integration
+- No hosted dashboard
 - Findings are heuristic checks based on Docker Compose configuration
 - Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure
 
@@ -112,9 +191,7 @@ ExposeMap does not prove real internet exposure. It does not replace a full secu
 
 ## Roadmap
 
-- JSON report output
 - HTML report output
-- GitHub Actions integration
 - Better reverse proxy label support
 - Caddy config support
 - Nginx Proxy Manager support

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -1,0 +1,89 @@
+# CI Usage
+
+ExposeMap can run in CI as a lightweight Docker Compose exposure review step. It remains local, read-only, and Compose-based.
+
+ExposeMap does not prove real internet exposure, does not perform real network scans, does not connect to containers, and does not send `docker-compose.yml` files or reports anywhere.
+
+## Local Usage
+
+```bash
+npm install
+npm run build
+node dist/cli.js scan ./docker-compose.yml --format markdown
+```
+
+Markdown is the default:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml
+```
+
+## Docker Usage
+
+```bash
+docker build -t exposemap .
+docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format markdown
+```
+
+JSON output with a CI threshold:
+
+```bash
+docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format json --fail-on high
+```
+
+## JSON Output
+
+Use JSON when a CI job, script, or later reporting step needs structured data:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml --format json
+```
+
+The JSON report includes:
+
+- tool name and version
+- scanned file path
+- generated timestamp
+- summary counts
+- services
+- exposure map entries
+- findings
+- Mermaid diagram string
+
+## Fail-on Thresholds
+
+`--fail-on` controls whether ExposeMap exits non-zero after a successful scan.
+
+```bash
+node dist/cli.js scan ./docker-compose.yml --fail-on high
+node dist/cli.js scan ./docker-compose.yml --format json --fail-on medium
+```
+
+Supported values:
+
+- `none` - always exit `0` unless CLI usage or parsing fails
+- `high` - exit `1` if any high finding exists
+- `medium` - exit `1` if any medium or high finding exists
+- `low` - exit `1` if any low, medium, or high finding exists
+
+The default is `none` for backward compatibility.
+
+## Exit Codes
+
+- `0` - scan completed and the `--fail-on` threshold was not violated
+- `1` - scan completed and the `--fail-on` threshold was violated
+- `2` - invalid CLI usage, unsupported options, missing files, or Compose parsing errors
+
+## GitHub Actions Example
+
+See [github-actions-example.yml](github-actions-example.yml).
+
+The example installs dependencies, builds ExposeMap, runs Markdown and JSON scans, and shows how to use `--fail-on high`. It uses `examples/risky-compose.yml`, so the threshold step is expected to fail; replace the path with your own Compose file in real CI.
+
+## Recommended Usage for Self-hosted Projects
+
+- Start with `--fail-on none` and review the report manually.
+- Move to `--fail-on high` once obvious risky direct exposures are understood.
+- Use JSON output for artifacts, pull request summaries, or later automation.
+- Keep Compose snippets in public issues sanitized.
+- Review ExposeMap findings alongside firewall rules, reverse proxy config, VPN setup, DNS, and host-level controls.

--- a/docs/github-actions-example.yml
+++ b/docs/github-actions-example.yml
@@ -1,0 +1,47 @@
+name: ExposeMap
+
+on:
+  pull_request:
+    paths:
+      - "**/docker-compose*.yml"
+      - "**/compose*.yml"
+      - "examples/*.yml"
+  workflow_dispatch:
+
+jobs:
+  exposure-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build ExposeMap
+        run: npm run build
+
+      - name: Generate Markdown report
+        run: node dist/cli.js scan examples/risky-compose.yml --format markdown --fail-on none
+
+      - name: Generate JSON report
+        run: node dist/cli.js scan examples/risky-compose.yml --format json --fail-on none > exposemap-report.json
+
+      - name: Enforce high-severity threshold
+        # This intentionally fails for examples/risky-compose.yml.
+        # Replace the path with your own Compose file in real CI.
+        run: node dist/cli.js scan examples/risky-compose.yml --format json --fail-on high
+
+      - name: Upload JSON report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: exposemap-report
+          path: exposemap-report.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exposemap",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exposemap",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "commander": "^14.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exposemap",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Open-source exposure mapper for self-hosted Docker Compose services",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,34 +1,62 @@
 #!/usr/bin/env node
-import { Command } from "commander";
-import { scanComposeFileToMarkdown } from "./index.js";
+import { Command, CommanderError } from "commander";
+import { getExitCodeForReport, parseFailOnThreshold } from "./failOn.js";
+import { scanComposeFile } from "./index.js";
+import { renderJsonReport } from "./report/json.js";
+import { renderMarkdownReport } from "./report/markdown.js";
+import { getToolVersion } from "./version.js";
 
 const program = new Command();
+const supportedFormats = new Set(["markdown", "json"]);
 
 program
   .name("exposemap")
   .description("Open-source exposure mapper for self-hosted Docker Compose services")
-  .version("0.1.0");
+  .version(getToolVersion())
+  .exitOverride();
 
 program
   .command("scan")
   .argument("<compose-file>", "Path to docker-compose.yml")
-  .option("--format <format>", "Report format: markdown", "markdown")
+  .option("--format <format>", "Report format: markdown or json", "markdown")
+  .option("--fail-on <severity>", "Exit 1 on findings at or above severity: high, medium, low, none", "none")
   .description("Scan a Docker Compose file and print an exposure report")
-  .action(async (composeFile: string, options: { format: string }) => {
-    if (options.format !== "markdown") {
-      console.error(`Unsupported format: ${options.format}. The MVP currently supports markdown only.`);
-      process.exitCode = 1;
+  .action(async (composeFile: string, options: { format: string; failOn: string }) => {
+    const format = options.format.toLowerCase();
+    const failOn = parseFailOnThreshold(options.failOn.toLowerCase());
+
+    if (!supportedFormats.has(format)) {
+      console.error(`Unsupported format: ${options.format}. Supported formats: markdown, json.`);
+      process.exitCode = 2;
+      return;
+    }
+
+    if (!failOn) {
+      console.error(`Unsupported --fail-on value: ${options.failOn}. Supported values: high, medium, low, none.`);
+      process.exitCode = 2;
       return;
     }
 
     try {
-      const report = await scanComposeFileToMarkdown(composeFile);
-      process.stdout.write(report);
+      const report = await scanComposeFile(composeFile);
+      const output = format === "json" ? renderJsonReport(report) : renderMarkdownReport(report);
+      process.stdout.write(output);
+      process.exitCode = getExitCodeForReport(report, failOn);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(`ExposeMap failed: ${message}`);
-      process.exitCode = 1;
+      process.exitCode = 2;
     }
   });
 
-program.parseAsync();
+try {
+  await program.parseAsync();
+} catch (error) {
+  if (error instanceof CommanderError) {
+    process.exitCode = error.exitCode === 0 ? 0 : 2;
+  } else {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`ExposeMap failed: ${message}`);
+    process.exitCode = 2;
+  }
+}

--- a/src/failOn.ts
+++ b/src/failOn.ts
@@ -1,0 +1,30 @@
+import type { ExposureReport, Severity } from "./types.js";
+
+export type FailOnThreshold = Severity | "none";
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  low: 1,
+  medium: 2,
+  high: 3
+};
+
+export function parseFailOnThreshold(value: string): FailOnThreshold | null {
+  if (value === "none" || value === "low" || value === "medium" || value === "high") {
+    return value;
+  }
+
+  return null;
+}
+
+export function violatesFailOnThreshold(report: ExposureReport, threshold: FailOnThreshold): boolean {
+  if (threshold === "none") {
+    return false;
+  }
+
+  const minimumRank = SEVERITY_RANK[threshold];
+  return report.findings.some((finding) => SEVERITY_RANK[finding.severity] >= minimumRank);
+}
+
+export function getExitCodeForReport(report: ExposureReport, threshold: FailOnThreshold): 0 | 1 {
+  return violatesFailOnThreshold(report, threshold) ? 1 : 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { parseComposeFile } from "./parser.js";
 import { analyzeProject } from "./rules/serviceClassifier.js";
+import { renderJsonReport } from "./report/json.js";
 import { renderMarkdownReport } from "./report/markdown.js";
 import type { ExposureReport } from "./types.js";
 
@@ -13,8 +14,15 @@ export async function scanComposeFileToMarkdown(filePath: string): Promise<strin
   return renderMarkdownReport(report);
 }
 
+export async function scanComposeFileToJson(filePath: string): Promise<string> {
+  const report = await scanComposeFile(filePath);
+  return renderJsonReport(report);
+}
+
 export * from "./types.js";
 export { parseComposeContent, parseComposeFile } from "./parser.js";
 export { analyzeProject, analyzeService } from "./rules/serviceClassifier.js";
+export { parseFailOnThreshold, getExitCodeForReport, violatesFailOnThreshold } from "./failOn.js";
+export { buildJsonReport, renderJsonReport } from "./report/json.js";
 export { renderMarkdownReport } from "./report/markdown.js";
 export { renderMermaidDiagram } from "./report/mermaid.js";

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -1,0 +1,165 @@
+import type { ExposureClassification, ExposureReport, Finding, PortMapping, ServiceAnalysis } from "../types.js";
+import { TOOL_NAME, getToolVersion } from "../version.js";
+
+interface JsonSummary {
+  totalServices: number;
+  internal: number;
+  localhostOnly: number;
+  directlyExposed: number;
+  reverseProxyExposed: number;
+  unknown: number;
+  totalFindings: number;
+  high: number;
+  medium: number;
+  low: number;
+}
+
+interface JsonService {
+  name: string;
+  classification: ExposureClassification;
+  image?: string;
+  ports: JsonPort[];
+  labels: Record<string, string>;
+  evidence: string[];
+  notes: string[];
+}
+
+interface JsonPort {
+  evidence: string;
+  hostIp?: string;
+  published?: string;
+  target?: string;
+  protocol?: string;
+  isLocalhostBound: boolean;
+  isBroadlyBound: boolean;
+}
+
+interface JsonExposureMapEntry {
+  service: string;
+  classification: ExposureClassification;
+  entrypoints: string[];
+  evidence: string[];
+}
+
+export interface JsonExposureReport {
+  tool: {
+    name: string;
+    version: string;
+  };
+  scannedFilePath: string;
+  generatedAt: string;
+  summary: JsonSummary;
+  services: JsonService[];
+  exposureMap: JsonExposureMapEntry[];
+  findings: Finding[];
+  mermaid: string;
+}
+
+export function buildJsonReport(report: ExposureReport): JsonExposureReport {
+  return {
+    tool: {
+      name: TOOL_NAME,
+      version: getToolVersion()
+    },
+    scannedFilePath: report.filePath,
+    generatedAt: report.generatedAt,
+    summary: buildSummary(report),
+    services: report.services.map(buildService),
+    exposureMap: report.services.map(buildExposureMapEntry),
+    findings: report.findings,
+    mermaid: report.mermaid
+  };
+}
+
+export function renderJsonReport(report: ExposureReport): string {
+  return `${JSON.stringify(buildJsonReport(report), null, 2)}\n`;
+}
+
+function buildSummary(report: ExposureReport): JsonSummary {
+  return {
+    totalServices: report.services.length,
+    internal: countServices(report, "internal"),
+    localhostOnly: countServices(report, "localhost-only"),
+    directlyExposed: countServices(report, "directly exposed"),
+    reverseProxyExposed: countServices(report, "reverse-proxy exposed"),
+    unknown: countServices(report, "unknown"),
+    totalFindings: report.findings.length,
+    high: countFindings(report, "high"),
+    medium: countFindings(report, "medium"),
+    low: countFindings(report, "low")
+  };
+}
+
+function buildService(service: ServiceAnalysis): JsonService {
+  return {
+    name: service.service.name,
+    classification: service.classification,
+    image: service.service.image,
+    ports: service.ports.map(buildPort),
+    labels: service.service.labels,
+    evidence: buildEvidence(service),
+    notes: service.notes
+  };
+}
+
+function buildPort(port: PortMapping): JsonPort {
+  return {
+    evidence: port.evidence,
+    hostIp: port.hostIp,
+    published: port.published,
+    target: port.target,
+    protocol: port.protocol,
+    isLocalhostBound: port.isLocalhostBound,
+    isBroadlyBound: port.isBroadlyBound
+  };
+}
+
+function buildExposureMapEntry(service: ServiceAnalysis): JsonExposureMapEntry {
+  return {
+    service: service.service.name,
+    classification: service.classification,
+    entrypoints: getEntrypoints(service),
+    evidence: buildEvidence(service)
+  };
+}
+
+function buildEvidence(service: ServiceAnalysis): string[] {
+  const evidence = service.ports.map((port) => port.evidence);
+
+  if (service.isReverseProxy) {
+    evidence.push("likely reverse proxy service");
+  }
+
+  if (service.hasReverseProxyRouting) {
+    evidence.push("reverse proxy routing labels/env detected");
+  }
+
+  if (service.ports.length === 0) {
+    evidence.push("no Compose ports detected");
+  }
+
+  return evidence;
+}
+
+function getEntrypoints(service: ServiceAnalysis): string[] {
+  switch (service.classification) {
+    case "directly exposed":
+      return ["internet"];
+    case "localhost-only":
+      return ["localhost"];
+    case "reverse-proxy exposed":
+      return ["reverse-proxy"];
+    case "internal":
+      return ["internal-network"];
+    case "unknown":
+      return ["unknown"];
+  }
+}
+
+function countServices(report: ExposureReport, classification: ExposureClassification): number {
+  return report.services.filter((service) => service.classification === classification).length;
+}
+
+function countFindings(report: ExposureReport, severity: Finding["severity"]): number {
+  return report.findings.filter((finding) => finding.severity === severity).length;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,18 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+interface PackageJson {
+  version?: string;
+}
+
+export const TOOL_NAME = "ExposeMap";
+
+export function getToolVersion(): string {
+  try {
+    const packageJson = require("../package.json") as PackageJson;
+    return packageJson.version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}

--- a/tests/failOn.test.ts
+++ b/tests/failOn.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { getExitCodeForReport, parseFailOnThreshold, violatesFailOnThreshold } from "../src/failOn.js";
+import type { ExposureReport, Finding } from "../src/types.js";
+
+describe("fail-on threshold handling", () => {
+  it("parses supported thresholds", () => {
+    expect(parseFailOnThreshold("none")).toBe("none");
+    expect(parseFailOnThreshold("low")).toBe("low");
+    expect(parseFailOnThreshold("medium")).toBe("medium");
+    expect(parseFailOnThreshold("high")).toBe("high");
+    expect(parseFailOnThreshold("critical")).toBeNull();
+  });
+
+  it("does not fail when threshold is none", () => {
+    expect(violatesFailOnThreshold(reportWithFindings(["high"]), "none")).toBe(false);
+    expect(getExitCodeForReport(reportWithFindings(["high"]), "none")).toBe(0);
+  });
+
+  it("fails on high only for high threshold", () => {
+    expect(violatesFailOnThreshold(reportWithFindings(["medium"]), "high")).toBe(false);
+    expect(getExitCodeForReport(reportWithFindings(["high"]), "high")).toBe(1);
+  });
+
+  it("fails on medium and high for medium threshold", () => {
+    expect(getExitCodeForReport(reportWithFindings(["low"]), "medium")).toBe(0);
+    expect(getExitCodeForReport(reportWithFindings(["medium"]), "medium")).toBe(1);
+    expect(getExitCodeForReport(reportWithFindings(["high"]), "medium")).toBe(1);
+  });
+
+  it("fails on any finding for low threshold", () => {
+    expect(getExitCodeForReport(reportWithFindings([]), "low")).toBe(0);
+    expect(getExitCodeForReport(reportWithFindings(["low"]), "low")).toBe(1);
+    expect(getExitCodeForReport(reportWithFindings(["medium"]), "low")).toBe(1);
+    expect(getExitCodeForReport(reportWithFindings(["high"]), "low")).toBe(1);
+  });
+});
+
+function reportWithFindings(severities: Finding["severity"][]): ExposureReport {
+  return {
+    filePath: "compose.yml",
+    services: [],
+    findings: severities.map((severity) => ({
+      ruleId: `${severity}-rule`,
+      severity,
+      service: "app",
+      title: `${severity} finding`,
+      description: "Test finding",
+      evidence: "test",
+      recommendation: "Review the service."
+    })),
+    generatedAt: "2026-04-28T00:00:00.000Z",
+    mermaid: "graph TD"
+  };
+}

--- a/tests/json.test.ts
+++ b/tests/json.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { parseComposeContent } from "../src/parser.js";
+import { buildJsonReport, renderJsonReport } from "../src/report/json.js";
+import { analyzeProject } from "../src/rules/serviceClassifier.js";
+import { getToolVersion } from "../src/version.js";
+
+describe("JSON report output", () => {
+  it("renders a structured CI-friendly report", () => {
+    const report = analyzeProject(
+      parseComposeContent(
+        `
+services:
+  traefik:
+    image: traefik:v3
+    ports:
+      - "80:80"
+  app:
+    image: ghcr.io/example/app:latest
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.app.rule: Host(\`app.example.test\`)
+    depends_on:
+      - db
+  db:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+  admin:
+    image: adminer:latest
+    ports:
+      - "127.0.0.1:8080:8080"
+  worker:
+    image: ghcr.io/example/worker:latest
+`,
+        "compose.yml"
+      )
+    );
+
+    const json = buildJsonReport(report);
+
+    expect(json.tool.name).toBe("ExposeMap");
+    expect(json.tool.version).toBe(getToolVersion());
+    expect(json.scannedFilePath).toBe("compose.yml");
+    expect(Date.parse(json.generatedAt)).not.toBeNaN();
+    expect(json.summary).toMatchObject({
+      totalServices: 5,
+      internal: 1,
+      localhostOnly: 1,
+      directlyExposed: 2,
+      reverseProxyExposed: 1,
+      unknown: 0,
+      totalFindings: 3,
+      high: 1,
+      medium: 0,
+      low: 2
+    });
+    expect(json.services.find((service) => service.name === "app")).toMatchObject({
+      classification: "reverse-proxy exposed",
+      labels: {
+        "traefik.enable": "true"
+      },
+      evidence: expect.arrayContaining(["reverse proxy routing labels/env detected"])
+    });
+    expect(json.exposureMap).toContainEqual(
+      expect.objectContaining({
+        service: "db",
+        classification: "directly exposed",
+        entrypoints: ["internet"],
+        evidence: ["5432:5432"]
+      })
+    );
+    expect(json.findings[0]).toMatchObject({
+      ruleId: "risky-direct-port",
+      severity: "high",
+      service: "db"
+    });
+    expect(json.mermaid).toContain("graph TD");
+  });
+
+  it("renders parseable JSON text", () => {
+    const report = analyzeProject(
+      parseComposeContent(
+        `
+services:
+  app:
+    image: nginx
+`,
+        "compose.yml"
+      )
+    );
+
+    const parsed = JSON.parse(renderJsonReport(report));
+
+    expect(parsed.tool.name).toBe("ExposeMap");
+    expect(parsed.summary.totalServices).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds CI-friendly JSON report output while keeping Markdown as the default.
- Adds `--fail-on` thresholds for high, medium, low, and none.
- Makes exit codes deterministic for successful scans, threshold violations, and CLI/parsing errors.
- Adds GitHub Actions usage documentation and an example workflow.

## New CLI options
- `--format json` prints a structured JSON report with summary counts, services, exposure map entries, findings, and Mermaid output.
- `--fail-on none` exits 0 unless usage/parsing fails.
- `--fail-on high` exits 1 when high findings exist.
- `--fail-on medium` exits 1 when medium or high findings exist.
- `--fail-on low` exits 1 when any finding exists.

## Tests run
- `npm install`
- `npm test`
- `npm run build`
- `node dist/cli.js scan examples/risky-compose.yml --format markdown`
- `node dist/cli.js scan examples/risky-compose.yml --format json`
- `node dist/cli.js scan examples/risky-compose.yml --fail-on high` confirmed exit code 1
- Invalid format and missing file checks confirmed exit code 2

## Docker command tested
- `docker build -t exposemap .`
- `docker run --rm -v $(pwd):/scan exposemap scan /scan/examples/risky-compose.yml --format json`

## Current limitations
- Compose-based heuristic checks only.
- Does not prove real internet exposure.
- Does not perform real network scans.
- Does not connect to containers.
- No Kubernetes, Cloudflare Tunnel API, Tailscale API, hosted dashboard, or cloud functionality.