### PR TITLE
docs: add paid path entrypoints

### DIFF
--- a/.github/ISSUE_TEMPLATE/early_access_request.md
+++ b/.github/ISSUE_TEMPLATE/early_access_request.md
@@ -1,0 +1,55 @@
+---
+name: Early Access Request
+about: Share interest in a future hosted SelfHostGuard dashboard
+title: "Early access request: "
+labels: question
+assignees: ""
+---
+
+Do not paste secrets, credentials, private compose files, or sensitive infrastructure details.
+
+## What are you running?
+
+Briefly describe the kind of self-hosted services or stacks you manage.
+
+## How many Docker Compose stacks do you manage?
+
+Example: 1, 2-5, 6-20, 20+
+
+## Which tools do you use?
+
+- [ ] Traefik
+- [ ] Caddy
+- [ ] Nginx Proxy Manager
+- [ ] SWAG
+- [ ] Tailscale
+- [ ] WireGuard
+- [ ] Cloudflare Tunnel
+- [ ] Other:
+
+## Do you need scheduled exposure checks?
+
+Yes / No / Not sure
+
+## Do you need alerts when new services become exposed?
+
+Yes / No / Not sure
+
+## Do you need Slack / Discord alerts?
+
+Yes / No / Not sure
+
+## Are you interested in a hosted dashboard?
+
+Yes / No / Not sure
+
+## Usage type
+
+- [ ] Personal
+- [ ] Homelab
+- [ ] Team
+- [ ] Company
+
+## Contact method, optional
+
+GitHub is fine. Add another contact method only if you are comfortable sharing it.

--- a/.github/ISSUE_TEMPLATE/setup_review_request.md
+++ b/.github/ISSUE_TEMPLATE/setup_review_request.md
@@ -1,0 +1,47 @@
+---
+name: Setup Review Request
+about: Request interest in a paid exposure, reverse proxy, or access setup review
+title: "Setup review request: "
+labels: question
+assignees: ""
+---
+
+Do not paste secrets, credentials, private compose files, or sensitive infrastructure details.
+
+## What kind of exposure setup do you want reviewed?
+
+Briefly describe the setup and what you want checked.
+
+## Main concern
+
+- [ ] Public ports
+- [ ] Reverse proxy
+- [ ] Tailscale
+- [ ] Cloudflare Tunnel
+- [ ] Admin panels
+- [ ] Database exposure
+- [ ] Other:
+
+## Approximate number of services
+
+Example: 1-5, 6-20, 20+
+
+## Reverse proxy or VPN tools used
+
+Example: Traefik, Caddy, Nginx Proxy Manager, SWAG, Tailscale, WireGuard, Cloudflare Tunnel.
+
+## Docker Compose snippet, without secrets, optional
+
+```yaml
+services:
+  app:
+    image: example/app
+```
+
+## Preferred contact method, optional
+
+GitHub is fine. Add another contact method only if you are comfortable sharing it.
+
+## Urgency, optional
+
+Example: no rush, this week, before launch, active incident.

--- a/README.md
+++ b/README.md
@@ -210,9 +210,28 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
 
 For now, GitHub issues and discussions are the best place to share examples, edge cases, and ideas. Please do not paste private Compose files, secrets, credentials, or sensitive infrastructure details into public issues.
 
-## Hosted Version / Support Note
+## Hosted Dashboard / Paid Support
 
-Hosted dashboards, scheduled exposure checks, alerts, and setup reviews may come later. If you are interested, open an issue or contact the maintainer.
+ExposeMap is free and open source.
+
+A hosted SelfHostGuard Cloud dashboard may come later for teams that want:
+
+- scheduled exposure checks
+- scan history
+- exposure diffs over time
+- alerts when new services appear exposed
+- GitHub Actions integration
+- Slack / Discord alerts
+- multi-stack monitoring
+- team reports
+
+This hosted dashboard does not exist yet, and ExposeMap still does not prove real internet exposure. Real external exposure testing, firewall review, DNS review, and infrastructure review remain separate work.
+
+More context is in [docs/paid-support.md](docs/paid-support.md).
+
+If you want early access, open an [Early Access Request](https://github.com/kozinkaihatusya/exposemap/issues/new?template=early_access_request.md).
+
+If you need help reviewing your self-hosted exposure, reverse proxy, or Tailscale setup, open a [Setup Review Request](https://github.com/kozinkaihatusya/exposemap/issues/new?template=setup_review_request.md).
 
 ## License
 

--- a/docs/paid-support.md
+++ b/docs/paid-support.md
@@ -1,0 +1,40 @@
+# Paid Support and Early Access
+
+ExposeMap CLI is free and open source.
+
+The hosted SelfHostGuard Cloud dashboard is not available yet. This document is for collecting interest and shaping what may be useful later.
+
+## Possible Hosted Dashboard Features
+
+- scheduled exposure checks
+- scan history
+- exposure diffs
+- alerts for newly exposed services
+- GitHub Actions integration
+- Slack / Discord alerts
+- multi-stack monitoring
+- team reports
+
+These are possible future features, not a promise that they already exist.
+
+## Possible Paid Setup Review
+
+Paid setup review may be considered for people or teams who want help reviewing self-hosted exposure paths. Possible review areas:
+
+- exposure map review
+- reverse proxy review
+- public port review
+- Tailscale / WireGuard / VPN review
+- admin panel exposure review
+- written report
+
+This would still be separate from real external exposure testing. ExposeMap itself remains a local, Compose-based configuration review tool and does not prove internet reachability.
+
+## Enterprise / Self-hosting Support
+
+Enterprise or self-hosting support may be considered later for teams that want help using ExposeMap across multiple stacks or integrating reports into internal workflows.
+
+No fixed pricing is available yet, and support is not guaranteed. For now, use the issue templates to share interest:
+
+- [Early Access Request](https://github.com/kozinkaihatusya/exposemap/issues/new?template=early_access_request.md)
+- [Setup Review Request](https://github.com/kozinkaihatusya/exposemap/issues/new?template=setup_review_request.md)

--- a/launch/devto-article.md
+++ b/launch/devto-article.md
@@ -102,4 +102,10 @@ It runs locally, does not modify Compose files, does not connect to containers, 
 
 That last point matters: ExposeMap is not a full security audit and does not prove internet exposure. It is a lightweight configuration review tool based on Compose heuristics.
 
+## What might come next
+
+The CLI is free and open source. Longer term, I am collecting interest in a hosted SelfHostGuard dashboard for scheduled exposure checks, scan history, exposure diffs, and alerts when new services appear exposed.
+
+That would still be separate from real external exposure testing. The current tool remains local, read-only, and Compose-based.
+
 GitHub: https://github.com/kozinkaihatusya/exposemap

--- a/launch/hacker-news.md
+++ b/launch/hacker-news.md
@@ -18,4 +18,6 @@ The goal is not to prove real internet exposure. It does not perform network sca
 
 The MVP currently handles common port mappings, localhost bindings, Traefik-style labels, likely reverse proxy services, and risky directly exposed database/admin ports.
 
+Longer term, I am also collecting interest for scheduled checks, history, diffs, and alerts, but the current project is just the free local CLI.
+
 Feedback, edge cases, and sanitized Compose examples are welcome.

--- a/launch/reddit-selfhosted.md
+++ b/launch/reddit-selfhosted.md
@@ -25,4 +25,6 @@ Important caveat: it does not perform real network scans and does not prove inte
 
 The MVP checks common port mappings, localhost-only bindings, broad/public bindings, Traefik labels, likely reverse proxy services, and risky directly exposed ports like Postgres, Redis, MySQL, MongoDB, Elasticsearch, and common admin panels.
 
+I'm also collecting interest for a hosted SelfHostGuard dashboard and exposure setup reviews, but the CLI itself is free and open source.
+
 I would appreciate feedback, edge cases, and sanitized Compose examples. If you find it useful, a GitHub star would help other self-hosters find it.


### PR DESCRIPTION
## Summary
- Adds README entrypoints for future SelfHostGuard Cloud early access and paid setup review interest.
- Adds GitHub issue templates for early access requests and setup review requests.
- Adds docs/paid-support.md explaining possible future hosted dashboard, paid review, and enterprise/self-hosting support paths.
- Lightly updates launch drafts without making the paid path the main CTA.

## Files changed
- `README.md`
- `.github/ISSUE_TEMPLATE/early_access_request.md`
- `.github/ISSUE_TEMPLATE/setup_review_request.md`
- `docs/paid-support.md`
- `launch/reddit-selfhosted.md`
- `launch/hacker-news.md`
- `launch/devto-article.md`

## Tests run
- `npm install`
- `npm test`
- `npm run build`
- `docker build -t exposemap .`

## What this does not implement
- No hosted dashboard.
- No payments.
- No authentication.
- No cloud functionality.
- No new product features.
- No real network scanning.
- No container connections.
- No Cloudflare, Tailscale, DNS, or external service queries.

## Manual follow-up
- Review incoming early access and setup review issues manually.
- Decide later whether to add dedicated labels for early access and setup review requests.