### PR TITLE
Improve OSS launch contribution intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,8 @@ labels: bug
 assignees: ""
 ---
 
+Before posting, remove secrets, credentials, private domains, internal hostnames, customer names, private IP details, and sensitive infrastructure details. ExposeMap only reviews Compose configuration and does not prove real internet reachability.
+
 ## Environment
 
 - OS:
@@ -29,13 +31,20 @@ What happened instead?
 
 ## Compose Snippet Without Secrets
 
-Please include the smallest sanitized Compose snippet that reproduces the issue.
+Please include the smallest sanitized Compose snippet that reproduces the issue. Do not paste a full private Compose file.
 
 ```yaml
 services:
   app:
     image: example/app
 ```
+
+## Classification Context, If Relevant
+
+- Which service was classified unexpectedly?
+- What classification did ExposeMap report?
+- What classification did you expect?
+- Which Compose field, port mapping, or label seems relevant?
 
 ## Logs Without Secrets
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,8 @@ labels: enhancement
 assignees: ""
 ---
 
+Please keep requests scoped to local, read-only Docker Compose review. ExposeMap does not perform live network scans, connect to containers, provide hosted monitoring, or accept private setup review requests.
+
 ## Problem
 
 What problem would this solve?
@@ -27,3 +29,11 @@ services:
   app:
     image: example/app
 ```
+
+## Scope Check
+
+- [ ] This can be implemented from Compose configuration only.
+- [ ] This does not require live network scanning.
+- [ ] This does not require connecting to containers.
+- [ ] This does not require hosted/cloud functionality.
+- [ ] This does not require private infrastructure details.

--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,40 @@
+---
+name: Good first issue idea
+about: Suggest a small, safe contribution for new contributors
+title: ""
+labels: good first issue
+assignees: ""
+---
+
+## Small Task
+
+What small task should a new contributor work on?
+
+## Why It Helps
+
+Why would this make ExposeMap clearer, safer, or easier to use?
+
+## Suggested Files
+
+- `README.md`
+- `docs/`
+- `examples/`
+- `src/`
+- `tests/`
+
+## Reproducible Example, If Relevant
+
+Use a sanitized Compose snippet only. Do not include secrets, private domains, internal hostnames, credentials, or sensitive infrastructure details.
+
+```yaml
+services:
+  app:
+    image: example/app
+```
+
+## Acceptance Criteria
+
+- [ ] The task stays local and read-only.
+- [ ] The change can be tested or reviewed from public examples.
+- [ ] No private infrastructure details are required.
+- [ ] Docs are updated if behavior or usage changes.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,31 @@
+---
+name: Question
+about: Ask a usage question that may become documentation
+title: ""
+labels: question
+assignees: ""
+---
+
+## Question
+
+What are you trying to understand?
+
+## What You Tried
+
+```bash
+node dist/cli.js scan ./docker-compose.yml --format markdown
+```
+
+## Sanitized Context
+
+If a Compose snippet helps, include the smallest sanitized example. Do not include secrets, private domains, internal hostnames, credentials, tokens, customer names, or sensitive infrastructure details.
+
+```yaml
+services:
+  app:
+    image: example/app
+```
+
+## Expected Documentation
+
+Where would you expect this to be explained?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,22 @@ npm run build
 node dist/cli.js scan examples/risky-compose.yml --format markdown
 ```
 
+## Good First Contributions
+
+Good first contributions should be small, reproducible, and based on public sanitized examples.
+
+Good areas include:
+
+- documentation wording
+- sanitized Docker Compose examples
+- parser edge cases with a focused test
+- reverse proxy label hints
+- report wording and Markdown formatting
+- tests for an existing rule
+- Docker and CI usage docs
+
+Avoid issues or PRs that require live infrastructure, external scanning, private Compose files, credentials, hosted services, authentication, customer-specific context, or paid support workflows.
+
 ## Add a New Rule
 
 1. Add the rule implementation under `src/rules/`.
@@ -41,7 +57,20 @@ node dist/cli.js scan examples/risky-compose.yml --format markdown
 - Use a concise title.
 - Include the command you ran and the output you expected.
 - Include sanitized Compose snippets only.
-- Do not include secrets, tokens, private domains, credentials, private IP details, or sensitive infrastructure information.
+- Do not include secrets, tokens, private domains, internal hostnames, credentials, private IP details, customer names, or sensitive infrastructure information.
+- If the change affects a user-visible classification, report, CLI option, Docker usage, or CI usage, update the relevant docs.
+- Link the issue or describe the reproducible case in the PR.
+
+## Issue Triage Labels
+
+Maintainers can use these labels to make the project easier to scan:
+
+- `bug` for incorrect behavior or unexpected errors
+- `enhancement` for feature requests
+- `docs` for documentation-only work
+- `good first issue` for small, well-scoped work that does not require private infrastructure
+- `needs sanitized example` when the report needs a smaller public Compose snippet
+- `question` for usage questions that may become docs
 
 ## Coding Style
 
@@ -50,3 +79,12 @@ node dist/cli.js scan examples/risky-compose.yml --format markdown
 - Avoid broad refactors in small PRs.
 - Do not add network scanning, hosted dashboards, authentication, or container connections unless the issue explicitly calls for it.
 - Run `npm test` and `npm run build` before opening a PR.
+
+## Pull Request Checklist
+
+- [ ] The change stays local and read-only.
+- [ ] No secrets, private Compose files, credentials, private domains, or sensitive infrastructure details are included.
+- [ ] Tests were added or updated when behavior changed.
+- [ ] `npm test` passes.
+- [ ] `npm run build` passes.
+- [ ] README or docs were updated when user-visible behavior changed.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In this README, "appears exposed" means published or mapped by the selected Dock
 
 ExposeMap runs locally and reads only the Compose file you choose. It does not upload Compose files, reports, service names, labels, secrets, or infrastructure details. It does not connect to containers, change infrastructure, or run live network scans.
 
-Point ExposeMap at a `docker-compose.yml` file and get a Markdown or JSON report you can review before deploying, share during a self-hosted setup review, or run in CI when Compose files change.
+Point ExposeMap at a `docker-compose.yml` file and get a Markdown or JSON report you can review before deploying, share during an internal review, or run in CI when Compose files change.
 
 ```bash
 npm install
@@ -25,7 +25,7 @@ Example output:
 | `admin` | localhost-only | binds to `127.0.0.1` |
 | `worker` | internal | no published ports |
 
-ExposeMap also generates a Mermaid diagram of likely exposure paths, so a Compose file becomes easier to discuss in issues, pull requests, setup reviews, and team handoffs.
+ExposeMap also generates a Mermaid diagram of likely exposure paths, so a Compose file becomes easier to discuss in issues, pull requests, internal reviews, and team handoffs.
 
 ## What ExposeMap Is
 
@@ -234,9 +234,19 @@ Those tools can be part of the setup, but the Compose file can still publish por
 
 The CLI, local reports, Docker usage, JSON output, CI usage, and Mermaid diagrams are free and open source.
 
-### What might be paid later?
+### Are hosted dashboards, setup reviews, or support plans available now?
 
-Future paid options may include setup review, managed reporting, hosted monitoring, or commercial support for teams. These are not required to use the open-source tool.
+No. ExposeMap currently has no hosted dashboard, setup review intake, pricing page, paid support plan, or service promise. The OSS CLI is the product to use and evaluate today.
+
+### Can I paste my real Compose file into an issue?
+
+Please do not paste private Compose files, `.env` files, credentials, tokens, private domains, internal hostnames, or sensitive infrastructure details into public issues. Reduce the case to the smallest sanitized snippet that still shows the behavior.
+
+### What kind of issues are useful right now?
+
+Useful issues include parser edge cases, incorrect classifications, reverse proxy label examples, unclear report wording, Docker usage problems, CI usage problems, and sanitized Compose examples that ExposeMap should handle better.
+
+See [docs/community.md](docs/community.md) for issue and contribution guidance.
 
 ## Current Limitations
 
@@ -269,23 +279,19 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
 
 ## Community
 
-For now, GitHub issues and discussions are the best place to share examples, edge cases, and ideas. Please do not paste private Compose files, secrets, credentials, or sensitive infrastructure details into public issues.
+For now, GitHub issues are the best place to share sanitized examples, edge cases, and ideas. Please do not paste private Compose files, secrets, credentials, private domains, internal hostnames, or sensitive infrastructure details into public issues.
 
-## Future Cloud and Support Options
+Read [docs/community.md](docs/community.md) before opening an issue.
+
+Issue templates are available for [bug reports](.github/ISSUE_TEMPLATE/bug_report.md), [feature requests](.github/ISSUE_TEMPLATE/feature_request.md), [questions](.github/ISSUE_TEMPLATE/question.md), and [good first issue ideas](.github/ISSUE_TEMPLATE/good_first_issue.md).
+
+## Future Notes
 
 ExposeMap is free and open source.
 
 The open-source CLI is the core product: local scanning, Markdown reports, JSON output, Docker usage, CI usage, and Mermaid diagrams should remain useful without any paid service.
 
-Future paid options may be explored if there is clear demand from self-hosters, small teams, or companies that want help operating ExposeMap across multiple stacks. Possible options include:
-
-- setup review for Docker Compose, reverse proxy, Tailscale, or WireGuard setups
-- managed reporting for multiple Compose stacks
-- scheduled checks and exposure diffs
-- team reports
-- commercial support for private self-hosted deployments
-
-These options are not required for the OSS launch and are not active product promises yet.
+A hosted dashboard, setup review intake, pricing page, paid support plan, or service promise is not available. Future options may be considered later only if the OSS project shows clear demand.
 
 ## License
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,68 @@
+# Community and Issue Guide
+
+ExposeMap is early and intentionally small. The best way to help right now is to make the Docker Compose review behavior clearer, safer, and easier to trust from public examples.
+
+## Current Community Home
+
+Use GitHub issues for:
+
+- incorrect or confusing classifications
+- parser edge cases
+- reverse proxy labels or Compose patterns ExposeMap should understand
+- documentation gaps
+- Docker or CI usage problems
+- small contribution ideas
+
+Do not use public issues for private setup reviews, urgent security help, paid support requests, or sharing sensitive infrastructure details.
+
+## Before Opening an Issue
+
+1. Run the latest version from the repository.
+2. Check whether the behavior is already listed in `README.md` or `docs/ci-usage.md`.
+3. Reduce the case to the smallest sanitized Compose snippet.
+4. Remove secrets, tokens, credentials, private domains, internal hostnames, private IP details, customer names, and private file paths.
+5. Include the exact command you ran and the output you expected.
+
+## Good First Issue Areas
+
+Good first issues should be small, reproducible, and safe for a new contributor to work on without needing private infrastructure.
+
+Good first areas include:
+
+- docs wording improvements
+- sanitized Compose examples
+- parser edge cases with a small fixture
+- reverse proxy label hints
+- report wording and Markdown formatting
+- tests for an existing rule
+- CI and Docker usage documentation
+
+Avoid good first issues that require live infrastructure, external scanning, private Compose files, credentials, hosted services, authentication, or customer-specific context.
+
+## Privacy and Safety Rules
+
+ExposeMap is a local, read-only Compose review tool. Public issues should follow the same boundary.
+
+Do not post:
+
+- `.env` files
+- API keys, tokens, passwords, certificates, or cookies
+- private Compose files
+- private domains or internal hostnames
+- IP addresses that identify private infrastructure
+- customer names, account IDs, or deployment details
+- screenshots that show sensitive service names or URLs
+
+If a real setup triggered the issue, replace names and values with neutral placeholders before posting.
+
+## What ExposeMap Can and Cannot Confirm
+
+ExposeMap can show what appears published, localhost-only, reverse-proxied, internal, or uncertain from a Docker Compose file.
+
+ExposeMap cannot prove real internet reachability. Firewalls, DNS, VPNs, tunnels, cloud security groups, reverse proxies, host rules, and runtime state can all change what is actually reachable.
+
+## Paid Support and Setup Reviews
+
+There is no active paid setup review, support plan, hosted dashboard, intake form, pricing page, or service promise.
+
+Please do not send private Compose files or sensitive infrastructure details for review.


### PR DESCRIPTION
## Summary
- add docs/community.md as the public issue and contribution guide
- clarify README FAQ/community sections around sanitized issues, non-active paid support, and issue templates
- expand CONTRIBUTING with good first contribution areas, triage labels, and a PR checklist
- add question and good-first-issue templates, and tighten bug/feature templates around safe sanitized examples

## GPT Pro review history
- 024: 修正. HN Show HN未成立後、外部投稿前にREADME/FAQ/Issues導線/community docsの最低限整備が必要。paid-support導線は時期尚早。
- 025: 承認. 受け皿整備は重大な不足なし。任意改善としてREADMEからcommunity docとIssue templatesへのリンク確認。
- 026: 承認. ローカルコミットは025承認内容に沿っている。push後、PR作成。

## Verification
- git diff --check
- npm test: 9 files / 24 tests passed
- npm run build
- node dist/cli.js scan examples/risky-compose.yml --format markdown --fail-on none

## Launch boundaries
- No external posts were made.
- No HN retry, Reddit/Lemmy/DEV/Medium/HackerNoon/X/LinkedIn/newsletter posts were made.
- No DM, Waitlist, Discord, pricing, npm publish, or real-user contact was performed.
- paid-support language remains non-active and non-promissory.