### PR TITLE
Refine Medium launch article

### DIFF
--- a/launch/medium-article.md
+++ b/launch/medium-article.md
@@ -34,11 +34,11 @@ ExposeMap parses Docker Compose configuration and reports exposure hints such as
 
 - internal
 - localhost-only
-- directly exposed from Compose config
-- reverse-proxy exposed
+- directly published in Compose config
+- likely reverse-proxy exposed from Compose labels
 - unknown
 
-It looks at common port mappings, localhost bindings, broad host bindings, Traefik-style labels, likely reverse proxy services, and directly published database, cache, search, or admin ports that deserve review.
+It looks at common port mappings, localhost bindings, broad host bindings, Traefik-style labels, likely reverse proxy services, and directly published database, cache, search, or admin ports that may deserve review.
 
 It also generates a Mermaid diagram so the likely exposure paths are easier to discuss in issues, pull requests, and internal reviews.
 

--- a/launch/medium-article.md
+++ b/launch/medium-article.md
@@ -1,59 +1,98 @@
-# How to see what your self-hosted Docker Compose stack exposes
-
-Self-hosted Docker Compose stacks often become difficult to reason about over time. A setup may start with one app and one database, then grow into a mix of admin panels, reverse proxies, caches, dashboards, VPNs, tunnels, and old experiments.
-
-Eventually, a simple question becomes surprisingly hard to answer: which services are reachable, and how?
-
-## Why exposure gets confusing
-
-Compose exposure often depends on small details. `5432:5432` and `127.0.0.1:5432:5432` are not equivalent. A service with no `ports` entry may still be routed through Traefik. A reverse proxy may rely on mounted config or external state that is not obvious from the Compose file alone.
-
-This does not mean Compose can prove real internet exposure. Firewalls, cloud security groups, DNS, VPNs, and host-level rules all matter. But Compose can still provide useful signals.
-
-## Directly exposing databases
-
-Database ports such as PostgreSQL `5432`, MySQL `3306`, Redis `6379`, MongoDB `27017`, and Elasticsearch/OpenSearch `9200` are worth reviewing carefully when they are published broadly.
-
-```yaml
-services:
-  postgres:
-    image: postgres:16
-    ports:
-      - "5432:5432"
-```
-
-For many stacks, localhost-only binding or no host port mapping is a safer default.
-
-## Localhost-only is different from broad binding
-
-These are easy to confuse:
-
-```yaml
-ports:
-  - "8080:8080"
-```
-
-```yaml
-ports:
-  - "127.0.0.1:8080:8080"
-```
-
-The first publishes broadly. The second binds to localhost. In a large Compose file, this difference is easy to miss.
-
-## Reverse proxies still need review
-
-Reverse proxies are useful, but they are not magic. Traefik labels, Caddyfiles, Nginx Proxy Manager state, host firewall rules, and VPN routing can all affect the real exposure path.
-
-Compose can show hints, but it cannot replace a full review.
-
-## Why I built ExposeMap
-
-I built ExposeMap as a small open-source CLI for self-hosted Docker Compose stacks.
-
-It scans `docker-compose.yml` and classifies services as internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown. It generates a Markdown report and a Mermaid diagram so you can quickly see likely exposure paths.
-
-ExposeMap runs locally. It does not modify Compose files, connect to containers, send reports anywhere, or perform real network scans.
+# Why I made a small Docker Compose exposure mapper open source
 
 GitHub: https://github.com/kaibuild/exposemap
 
-Technical feedback and sanitized Compose edge cases are welcome.
+I built ExposeMap because self-hosted Docker Compose stacks often become hard to reason about after a few months of real use.
+
+A Compose file may start with one app and one database. Later it has a reverse proxy, a dashboard, Redis, a monitoring service, a tunnel, a VPN, a few temporary admin panels, and old port mappings that were added during debugging and never removed.
+
+At that point, the useful question is not dramatic:
+
+Which services appear published, proxied, localhost-only, internal, or unclear from this Compose file?
+
+That is the narrow problem ExposeMap tries to solve.
+
+## Why this should be local first
+
+Compose files can contain sensitive infrastructure details: service names, internal hostnames, labels, image names, mounted paths, ports, and sometimes secrets that should not have been committed.
+
+For this kind of review tool, a hosted-first workflow would be the wrong default. I do not want people uploading private Compose files just to get a first-pass exposure map.
+
+ExposeMap is intentionally local and read-only:
+
+- it reads the Compose file you point it at
+- it does not upload Compose files or reports
+- it does not connect to containers
+- it does not modify infrastructure
+- it does not run live network scans
+
+The output is a Markdown or JSON report you can inspect yourself, share internally, or run in CI.
+
+## What it actually checks
+
+ExposeMap parses Docker Compose configuration and reports exposure hints such as:
+
+- internal
+- localhost-only
+- directly exposed from Compose config
+- reverse-proxy exposed
+- unknown
+
+It looks at common port mappings, localhost bindings, broad host bindings, Traefik-style labels, likely reverse proxy services, and directly published database, cache, search, or admin ports that deserve review.
+
+It also generates a Mermaid diagram so the likely exposure paths are easier to discuss in issues, pull requests, and internal reviews.
+
+## What it does not prove
+
+This is important: ExposeMap does not prove real internet reachability.
+
+Firewalls, cloud security groups, VPNs, tunnels, DNS, reverse proxies, and host rules can all change what is actually reachable. A Compose file is only one source of truth.
+
+So ExposeMap should be treated as a first-pass configuration review tool, not a security audit and not a vulnerability scanner.
+
+The goal is to make suspicious or confusing Compose exposure hints visible enough that a human can review them.
+
+## Why open source matters here
+
+I made it open source because the hard part is not just code. The hard part is edge cases.
+
+Self-hosted Compose setups vary a lot. People use different reverse proxies, different label conventions, different bind patterns, different admin tools, and different ways of separating internal and external services.
+
+If the tool is public, people can inspect the assumptions instead of trusting a black box. They can also point out where the wording is too strong, where a classification is misleading, or where a common Compose pattern is missing.
+
+That feedback loop is the main reason this project belongs on GitHub.
+
+## What I would like feedback on
+
+The most useful feedback right now is practical and specific:
+
+- sanitized Compose examples that are classified poorly
+- false positives around reverse proxy labels
+- false negatives around broad port publishing
+- wording that sounds too certain
+- report output that would be clearer in a pull request or CI job
+
+I am especially interested in examples that make the classification more honest, not more dramatic.
+
+## How to try it
+
+Clone the repo, install dependencies, build it, and run a scan against a Compose file:
+
+```bash
+npm install
+npm run build
+node dist/cli.js scan ./docker-compose.yml --format markdown
+```
+
+Docker usage is also supported:
+
+```bash
+docker build -t exposemap .
+docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format markdown
+```
+
+The README includes example output, Docker usage, JSON output, CI usage, exit codes, limitations, and a roadmap.
+
+GitHub: https://github.com/kaibuild/exposemap
+
+If you self-host with Docker Compose and have a sanitized edge case that ExposeMap should handle better, that is the kind of feedback I am looking for.


### PR DESCRIPTION
## Summary
- Rework the Medium launch article to focus on why ExposeMap is open source
- Emphasize local, read-only self-hosting review and GitHub feedback loops
- Keep the draft free of paid CTAs, star requests, DM prompts, or external publish actions

## Verification
- npm test
- npm run build
- node dist/cli.js scan examples/risky-compose.yml --format markdown

## Notes
- Lemmy.World Selfhosted post was created by the user at https://lemmy.world/post/47670272
- Reddit remains paused by user instruction
- This PR does not publish to Medium or any external site
