### PR TITLE
Align ExposeMap MVP visibility output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Purpose
 
-ExposeMap is a TypeScript CLI tool for self-hosted Docker Compose exposure mapping. It scans Compose configuration locally and reports whether services appear internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown.
+ExposeMap is a TypeScript CLI tool for self-hosted Docker Compose visibility mapping. It scans Compose configuration locally and reports whether services look `published`, `internal`, or `unknown`.
 
 ExposeMap must stay read-only in the MVP. It must not modify `docker-compose.yml`, connect to containers, scan external networks, or add hosted/cloud functionality unless explicitly requested.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # ExposeMap
 
-Turn your Docker Compose stack into a visual exposure map, so you can quickly see what appears exposed, internal, localhost-only, reverse-proxied, or needs review.
+Open-source exposure map for Docker Compose self-hosters.
 
-In this README, "appears exposed" means published or mapped by the selected Docker Compose file. It does not mean ExposeMap has proven that a service is reachable from the internet.
+ExposeMap reads local Docker Compose configuration and shows first-pass, configuration-based hints about which services look host-published.
 
-ExposeMap runs locally and reads only the Compose file you choose. It does not upload Compose files, reports, service names, labels, secrets, or infrastructure details. It does not connect to containers, change infrastructure, or run live network scans.
-
-Point ExposeMap at a `docker-compose.yml` file and get a Markdown or JSON report you can review before deploying, share during an internal review, or run in CI when Compose files change.
+Local. Read-only. No upload.
 
 ```bash
 npm install
@@ -16,203 +14,153 @@ node dist/cli.js scan ./docker-compose.yml
 
 Example output:
 
-| Service | Likely classification | Why it needs attention |
-| --- | --- | --- |
-| `traefik` | appears directly exposed | publishes `80:80` and `443:443` |
-| `web` | appears reverse-proxied | has Traefik routing labels |
-| `postgres` | needs review | publishes `5432:5432` |
-| `redis` | needs review | publishes `0.0.0.0:6379:6379` |
-| `admin` | localhost-only | binds to `127.0.0.1` |
-| `worker` | internal | no published ports |
+```text
+Service   Looks like   Why
+web       published    ports: 8080:80
+api       internal     expose only: 3000
+db        internal     no host-published ports
+admin     published    ports: 127.0.0.1:8080:80
+proxyish  unknown      proxy labels detected; note only in MVP
 
-ExposeMap also generates a Mermaid diagram of likely exposure paths, so a Compose file becomes easier to discuss in issues, pull requests, internal reviews, and team handoffs.
+published means host-published in Compose, not internet-reachable.
+internal means no host-published ports found, not impossible to reach.
+```
+
+ExposeMap reads local Compose configuration only.
+It does not test live reachability, firewall, DNS, VPN, tunnels, cloud security groups, or vulnerabilities.
+Do not paste real Compose files or secrets into public issues. Use sanitized examples only.
 
 ## What ExposeMap Is
 
-ExposeMap is a lightweight, read-only configuration review tool for self-hosters, homelab users, small teams, and developers running Docker Compose on VPS, NAS, home servers, public cloud servers, Tailscale, WireGuard, or reverse proxies.
+ExposeMap is a lightweight, read-only configuration review tool for self-hosters, homelab users, small teams, and developers running Docker Compose.
 
-It parses Docker Compose files, applies simple exposure heuristics, and prints a report showing which services appear internal, localhost-only, directly exposed from Compose configuration, reverse-proxy exposed, or unknown.
+It parses Compose files and prints a small map of what looks:
+
+- `published`
+- `internal`
+- `unknown`
+
+These are first-pass Compose configuration hints. They are not external reachability claims.
 
 ## Why ExposeMap Exists
 
-Self-hosted stacks often grow one service at a time: a database here, an admin panel there, a reverse proxy in front, maybe a VPN or tunnel later. After enough changes, it becomes hard to answer a basic question:
+Self-hosted stacks grow over time. After enough Compose edits, reverse proxy experiments, admin tools, databases, VPNs, and tunnels, it becomes hard to answer a simple question:
 
-Which services appear published, proxied, or internal from this Compose file?
+Which services look host-published from this Compose file?
 
-ExposeMap helps make that first-pass map visible from the Compose configuration you already have.
+ExposeMap makes that first-pass map visible without uploading the Compose file anywhere.
 
-## What It Maps
+## What It Checks
 
 - Docker Compose services
-- Short syntax port mappings such as `80:80`, `5432:5432`, and `127.0.0.1:8080:8080`
-- Long syntax Compose ports using `target`, `published`, and `host_ip`
-- Localhost-only bindings
-- Broad host bindings
-- Likely reverse proxy services
-- Traefik routing labels and obvious reverse proxy hints
-- Risky published database, cache, search, and admin ports
-- A Mermaid diagram of likely exposure paths
-- Markdown and JSON reports for local review or CI usage
+- `services.*.ports`
+- `services.*.expose`
+- `services.*.networks`
+- Optional labels as note-only context
 
-## Who It Is For
+## What It Does Not Check
 
-- self-hosters
-- homelab users
-- small teams running Docker Compose
-- developers running apps on VPS, NAS, home servers, public cloud servers, Tailscale, WireGuard, or reverse proxies
+- It does not scan the network.
+- It does not connect to containers.
+- It does not inspect secrets.
+- It does not verify firewall rules.
+- It does not verify DNS, VPNs, tunnels, or cloud security groups.
+- It does not prove internet reachability.
+- It is not a vulnerability scanner.
 
-## What You Get
+## Classification
 
-- A local Markdown report for quick review
-- JSON output for automation and CI
-- A Mermaid diagram of likely exposure paths
-- Findings for broad host bindings, localhost-only bindings, reverse proxy hints, and risky published database/cache/admin ports
-- Exit codes for CI with `--fail-on`
+### `published`
+
+The service has host-published Compose ports.
+
+Examples:
+
+- `8080:80`
+- `127.0.0.1:8080:80`
+- long syntax with `published`
+
+`published` means host-published in Compose, not internet-reachable.
+
+### `internal`
+
+The service has no host-published Compose ports.
+
+Examples:
+
+- `expose` only
+- no `ports`
+- attached to service networks without host-published ports
+
+`internal` means no host-published ports found, not impossible to reach.
+
+### `unknown`
+
+ExposeMap could not safely classify the service from the Compose file alone.
+
+Examples:
+
+- unsupported ports syntax
+- variable interpolation that needs expanded Compose config
+- reverse proxy labels, which are note-only in the MVP
 
 ## Quick Start
 
 ```bash
 npm install
 npm run build
+node dist/cli.js scan ./docker-compose.yml
+```
+
+Table output is the default:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml --format table
+```
+
+Markdown and JSON are also available:
+
+```bash
 node dist/cli.js scan ./docker-compose.yml --format markdown
+node dist/cli.js scan ./docker-compose.yml --format json
 ```
 
 If you install this repo as a local package, the bin name is:
 
 ```bash
-exposemap scan ./docker-compose.yml --format markdown
+exposemap scan ./docker-compose.yml --format table
 ```
-
-Markdown remains the default output:
-
-```bash
-node dist/cli.js scan ./docker-compose.yml
-```
-
-## JSON Output
-
-Use JSON when you want CI-friendly structured output:
-
-```bash
-node dist/cli.js scan ./docker-compose.yml --format json
-```
-
-The JSON report includes tool metadata, scanned file path, generated timestamp, summary counts, services, exposure map entries, findings, and the Mermaid diagram string.
-
-## Fail-on Thresholds
-
-Use `--fail-on` to make ExposeMap return exit code `1` when findings at or above a chosen severity are present:
-
-```bash
-node dist/cli.js scan ./docker-compose.yml --fail-on high
-node dist/cli.js scan ./docker-compose.yml --format json --fail-on medium
-```
-
-Supported values:
-
-- `none` - always exit `0` unless CLI usage or parsing fails
-- `high` - exit `1` if any high finding exists
-- `medium` - exit `1` if any medium or high finding exists
-- `low` - exit `1` if any low, medium, or high finding exists
-
-The default is `none` for backward compatibility.
 
 ## Exit Codes
 
 - `0` - scan completed and the `--fail-on` threshold was not violated
-- `1` - scan completed and the `--fail-on` threshold was violated
-- `2` - invalid CLI usage, unsupported options, missing files, or Compose parsing errors
+- `1` - scan failed, or scan completed and the `--fail-on` threshold was violated
+- `2` - invalid CLI usage or unsupported options
+
+The default `--fail-on` value is `none`.
 
 ## Run With Docker
 
 ```bash
 docker build -t exposemap .
-docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format markdown
-```
-
-Docker with JSON and CI threshold:
-
-```bash
-docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format json --fail-on high
+docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format table
 ```
 
 ## CI Usage
 
-ExposeMap can run in CI as a lightweight Compose-based exposure review step. It runs locally in the job, does not send `docker-compose.yml` files or reports anywhere, and does not perform real network scans.
+ExposeMap can run in CI as a lightweight Compose configuration review step. It runs locally in the job, does not send Compose files or reports anywhere, and does not perform live network scans.
 
 See [docs/ci-usage.md](docs/ci-usage.md) for local, Docker, JSON, and `--fail-on` examples.
 
-Example GitHub Actions workflow:
-
-```yaml
-name: ExposeMap
-
-on:
-  pull_request:
-    paths:
-      - "**/docker-compose*.yml"
-      - "**/compose*.yml"
-
-jobs:
-  exposemap:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - run: npm ci
-      - run: npm run build
-      - run: node dist/cli.js scan examples/risky-compose.yml --format json --fail-on high
-```
-
-The full example is available at [docs/github-actions-example.yml](docs/github-actions-example.yml). The example uses `examples/risky-compose.yml`, so the `--fail-on high` step is expected to fail; replace the path with your own Compose file in real CI.
-
 ## Example Report
 
-ExposeMap is most useful when the report makes a risky Compose stack visible at a glance. The example below is generated from a sample stack with a reverse proxy, a web service behind that proxy, database/cache services with published ports, a localhost-only admin service, and an internal worker.
-
-```markdown
-# ExposeMap Report
-
-Scanned file: `examples/risky-compose.yml`
-
-Total services: 6
-
-## Exposure Summary
-
-| Service | Likely classification | Ports | Reverse proxy hints |
-| --- | --- | --- | --- |
-| traefik | appears directly exposed | `80:80`<br>`443:443` | proxy service |
-| web | appears reverse-proxy exposed | - | routing labels/env |
-| postgres | needs review | `5432:5432` | - |
-| redis | needs review | `0.0.0.0:6379:6379` | - |
-```
-
 See [examples/report.md](examples/report.md) for a generated sample.
-
-## Mermaid Diagram Example
-
-```mermaid
-graph TD
-  Internet[Internet]
-  Localhost[Localhost]
-  InternalNetwork[Internal network]
-  Internet --> svc_traefik[traefik]
-  svc_traefik --> svc_web[web]
-  Internet --> svc_postgres[postgres]
-  Internet --> svc_redis[redis]
-  Localhost --> svc_admin[admin]
-  InternalNetwork --> svc_worker[worker]
-  svc_web --> svc_postgres[postgres]
-  svc_web --> svc_redis[redis]
-```
 
 ## FAQ
 
 ### Does ExposeMap prove that a service is reachable from the internet?
 
-No. ExposeMap reviews Docker Compose configuration and reports service exposure hints based on what is published or mapped in that file. Firewalls, VPNs, tunnels, DNS, cloud security groups, host rules, and reverse proxies can all change real-world reachability.
+No. ExposeMap reviews Docker Compose configuration and reports host-published hints based on that file. Firewalls, VPNs, tunnels, DNS, cloud security groups, host rules, reverse proxies, and runtime state can all change real-world reachability.
 
 ### Does ExposeMap upload my Compose file or report?
 
@@ -224,19 +172,7 @@ No. It does not connect to containers, read running container state, inspect sec
 
 ### Is this a vulnerability scanner?
 
-No. ExposeMap is a first-pass configuration review tool. It helps make likely exposure paths visible, but it does not replace external scanning, firewall review, threat modeling, or a security audit.
-
-### Why use this if I already have Traefik, Caddy, Nginx Proxy Manager, Tailscale, or WireGuard?
-
-Those tools can be part of the setup, but the Compose file can still publish ports directly, bind services broadly, or mix localhost-only and reverse-proxied services in ways that are hard to see. ExposeMap gives you a local map to review before assuming the setup is private.
-
-### What is free?
-
-The CLI, local reports, Docker usage, JSON output, CI usage, and Mermaid diagrams are free and open source.
-
-### Are hosted dashboards, setup reviews, or support plans available now?
-
-No. ExposeMap currently has no hosted dashboard, setup review intake, pricing page, paid support plan, or service promise. The OSS CLI is the product to use and evaluate today.
+No. ExposeMap is a first-pass configuration review tool. It does not replace external scanning, firewall review, threat modeling, or a security audit.
 
 ### Can I paste my real Compose file into an issue?
 
@@ -244,7 +180,7 @@ Please do not paste private Compose files, `.env` files, credentials, tokens, pr
 
 ### What kind of issues are useful right now?
 
-Useful issues include parser edge cases, incorrect classifications, reverse proxy label examples, unclear report wording, Docker usage problems, CI usage problems, and sanitized Compose examples that ExposeMap should handle better.
+Useful issues include parser edge cases, incorrect `published` / `internal` / `unknown` classifications, unclear report wording, Docker usage problems, CI usage problems, and sanitized Compose examples that ExposeMap should handle better.
 
 See [docs/community.md](docs/community.md) for issue and contribution guidance.
 
@@ -255,15 +191,15 @@ See [docs/community.md](docs/community.md) for issue and contribution guidance.
 - No Cloudflare Tunnel API integration
 - No Tailscale API integration
 - No hosted dashboard
-- Findings are heuristic checks based on Docker Compose configuration
+- Results are heuristic checks based on Docker Compose configuration
 - Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure
 
 ExposeMap does not prove real internet exposure. It does not replace a full security review, external exposure scan, firewall review, or threat model.
 
 ## Roadmap
 
-- HTML report output
 - Better reverse proxy label support
+- HTML report output
 - Caddy config support
 - Nginx Proxy Manager support
 - Cloudflare Tunnel hints
@@ -273,13 +209,13 @@ ExposeMap does not prove real internet exposure. It does not replace a full secu
 
 ## Contributing
 
-Contributions are welcome. Good first areas include parser edge cases, reverse proxy hints, report output, docs, and sanitized Compose examples.
+Contributions are welcome. Good first areas include parser edge cases, report output, docs, and sanitized Compose examples.
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
 
 ## Community
 
-For now, GitHub issues are the best place to share sanitized examples, edge cases, and ideas. Please do not paste private Compose files, secrets, credentials, private domains, internal hostnames, or sensitive infrastructure details into public issues.
+For now, GitHub issues are the best place to share sanitized examples, edge cases, and ideas.
 
 Read [docs/community.md](docs/community.md) before opening an issue.
 
@@ -289,7 +225,7 @@ Issue templates are available for [bug reports](.github/ISSUE_TEMPLATE/bug_repor
 
 ExposeMap is free and open source.
 
-The open-source CLI is the core product: local scanning, Markdown reports, JSON output, Docker usage, CI usage, and Mermaid diagrams should remain useful without any paid service.
+The open-source CLI is the core product: local table output, Markdown reports, JSON output, Docker usage, CI usage, and Mermaid diagrams should remain useful without any paid service.
 
 A hosted dashboard, setup review intake, pricing page, paid support plan, or service promise is not available. Future options may be considered later only if the OSS project shows clear demand.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ internal means no host-published ports found, not impossible to reach.
 ExposeMap reads local Compose configuration only.
 It does not test live reachability, firewall, DNS, VPN, tunnels, cloud security groups, or vulnerabilities.
 Do not paste real Compose files or secrets into public issues. Use sanitized examples only.
+Some Compose features, such as profiles, extends, include, anchors, merge keys, or variable interpolation, may require expanded Compose config for safer review.
 
 ## What ExposeMap Is
 
@@ -102,6 +103,7 @@ Examples:
 
 - unsupported ports syntax
 - variable interpolation that needs expanded Compose config
+- profiles, extends, include, anchors, or merge keys that need expanded Compose config
 - reverse proxy labels, which are note-only in the MVP
 
 ## Quick Start
@@ -192,6 +194,7 @@ See [docs/community.md](docs/community.md) for issue and contribution guidance.
 - No Tailscale API integration
 - No hosted dashboard
 - Results are heuristic checks based on Docker Compose configuration
+- Profiles, extends, include, anchors, merge keys, and variable interpolation may need expanded Compose config for safer review
 - Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure
 
 ExposeMap does not prove real internet exposure. It does not replace a full security review, external exposure scan, firewall review, or threat model.

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -44,6 +44,7 @@ The JSON report includes:
 - tool name and version
 - scanned file path
 - generated timestamp
+- disclaimers for local-only, configuration-only review
 - summary counts
 - services
 - exposure map entries
@@ -87,3 +88,4 @@ The example installs dependencies, builds ExposeMap, and runs table and JSON sca
 - Use JSON output for artifacts, pull request summaries, or later automation.
 - Keep Compose snippets in public issues sanitized.
 - Review ExposeMap notes alongside firewall rules, reverse proxy config, VPN setup, DNS, and host-level controls.
+- If your Compose setup uses profiles, extends, include, anchors, merge keys, or variable interpolation, consider reviewing an expanded Compose config too.

--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -1,6 +1,6 @@
 # CI Usage
 
-ExposeMap can run in CI as a lightweight Docker Compose exposure review step. It remains local, read-only, and Compose-based.
+ExposeMap can run in CI as a lightweight Docker Compose configuration review step. It remains local, read-only, and Compose-based.
 
 ExposeMap does not prove real internet exposure, does not perform real network scans, does not connect to containers, and does not send `docker-compose.yml` files or reports anywhere.
 
@@ -9,10 +9,10 @@ ExposeMap does not prove real internet exposure, does not perform real network s
 ```bash
 npm install
 npm run build
-node dist/cli.js scan ./docker-compose.yml --format markdown
+node dist/cli.js scan ./docker-compose.yml --format table
 ```
 
-Markdown is the default:
+Table output is the default:
 
 ```bash
 node dist/cli.js scan ./docker-compose.yml
@@ -22,7 +22,7 @@ node dist/cli.js scan ./docker-compose.yml
 
 ```bash
 docker build -t exposemap .
-docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format markdown
+docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format table
 ```
 
 JSON output with a CI threshold:
@@ -71,19 +71,19 @@ The default is `none` for backward compatibility.
 ## Exit Codes
 
 - `0` - scan completed and the `--fail-on` threshold was not violated
-- `1` - scan completed and the `--fail-on` threshold was violated
-- `2` - invalid CLI usage, unsupported options, missing files, or Compose parsing errors
+- `1` - scan failed, or scan completed and the `--fail-on` threshold was violated
+- `2` - invalid CLI usage or unsupported options
 
 ## GitHub Actions Example
 
 See [github-actions-example.yml](github-actions-example.yml).
 
-The example installs dependencies, builds ExposeMap, runs Markdown and JSON scans, and shows how to use `--fail-on high`. It uses `examples/risky-compose.yml`, so the threshold step is expected to fail; replace the path with your own Compose file in real CI.
+The example installs dependencies, builds ExposeMap, and runs table and JSON scans. Use `--fail-on` only after your team has agreed how to treat review notes in CI.
 
 ## Recommended Usage for Self-hosted Projects
 
 - Start with `--fail-on none` and review the report manually.
-- Move to `--fail-on high` once obvious risky direct exposures are understood.
+- Move to stricter `--fail-on` settings only after the output is understood.
 - Use JSON output for artifacts, pull request summaries, or later automation.
 - Keep Compose snippets in public issues sanitized.
-- Review ExposeMap findings alongside firewall rules, reverse proxy config, VPN setup, DNS, and host-level controls.
+- Review ExposeMap notes alongside firewall rules, reverse proxy config, VPN setup, DNS, and host-level controls.

--- a/docs/community.md
+++ b/docs/community.md
@@ -8,7 +8,7 @@ Use GitHub issues for:
 
 - incorrect or confusing classifications
 - parser edge cases
-- reverse proxy labels or Compose patterns ExposeMap should understand
+- reverse proxy labels or Compose patterns ExposeMap should treat as note-only context
 - documentation gaps
 - Docker or CI usage problems
 - small contribution ideas
@@ -32,7 +32,7 @@ Good first areas include:
 - docs wording improvements
 - sanitized Compose examples
 - parser edge cases with a small fixture
-- reverse proxy label hints
+- note-only reverse proxy label hints
 - report wording and Markdown formatting
 - tests for an existing rule
 - CI and Docker usage documentation
@@ -57,7 +57,10 @@ If a real setup triggered the issue, replace names and values with neutral place
 
 ## What ExposeMap Can and Cannot Confirm
 
-ExposeMap can show what appears published, localhost-only, reverse-proxied, internal, or uncertain from a Docker Compose file.
+ExposeMap can show whether a service looks `published`, `internal`, or `unknown` from a Docker Compose file.
+
+published means host-published in Compose, not internet-reachable.
+internal means no host-published ports found, not impossible to reach.
 
 ExposeMap cannot prove real internet reachability. Firewalls, DNS, VPNs, tunnels, cloud security groups, reverse proxies, host rules, and runtime state can all change what is actually reachable.
 

--- a/docs/github-actions-example.yml
+++ b/docs/github-actions-example.yml
@@ -28,16 +28,11 @@ jobs:
       - name: Build ExposeMap
         run: npm run build
 
-      - name: Generate Markdown report
-        run: node dist/cli.js scan examples/risky-compose.yml --format markdown --fail-on none
+      - name: Generate table report
+        run: node dist/cli.js scan examples/risky-compose.yml --format table --fail-on none
 
       - name: Generate JSON report
         run: node dist/cli.js scan examples/risky-compose.yml --format json --fail-on none > exposemap-report.json
-
-      - name: Enforce high-severity threshold
-        # This intentionally fails for examples/risky-compose.yml.
-        # Replace the path with your own Compose file in real CI.
-        run: node dist/cli.js scan examples/risky-compose.yml --format json --fail-on high
 
       - name: Upload JSON report
         if: always()

--- a/examples/report.md
+++ b/examples/report.md
@@ -4,49 +4,51 @@ Scanned file: `examples/risky-compose.yml`
 
 Total services: 6
 
-## Exposure Summary
+## Compose Visibility Summary
 
-| Service | Classification | Ports | Reverse proxy hints |
+| Service | Looks like | Why | Notes |
 | --- | --- | --- | --- |
-| traefik | directly exposed | `80:80`<br>`443:443` | proxy service |
-| web | reverse-proxy exposed | - | routing labels/env |
-| postgres | directly exposed | `5432:5432` | - |
-| redis | directly exposed | `0.0.0.0:6379:6379` | - |
-| admin | localhost-only | `127.0.0.1:8080:8080` | - |
-| worker | internal | - | - |
+| traefik | published | ports: 80:80, ports: 443:443 | - |
+| web | unknown | proxy labels detected; note only in MVP | Reverse proxy labels are note only in MVP and are not a formal classification. |
+| postgres | published | ports: 5432:5432 | - |
+| redis | published | ports: 0.0.0.0:6379:6379 | - |
+| admin | published | ports: 127.0.0.1:8080:8080 | Host binding is local, but MVP still reports host-published ports as published. |
+| worker | internal | no host-published ports | - |
 
-## High-risk Findings
+## Review Notes
 
-### PostgreSQL appears directly exposed
+### Service exposure is unknown
 
-- Severity: high
-- Service: `postgres`
-- Rule: `risky-direct-port`
-- Evidence: `5432:5432`
-- Recommendation: Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path.
+- Level: medium
+- Service: `web`
+- Rule: `unknown-exposure`
+- Evidence: `proxy labels detected; note only in MVP`
+- Recommendation: Review this service manually, including reverse proxy, VPN, firewall, and host-level configuration.
 
-This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.
+ExposeMap could not confidently classify this service from Compose configuration alone.
 
-### Redis appears directly exposed
+### Service appears internal
 
-- Severity: high
-- Service: `redis`
-- Rule: `risky-direct-port`
-- Evidence: `0.0.0.0:6379:6379`
-- Recommendation: Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path.
+- Level: low
+- Service: `worker`
+- Rule: `internal-service`
+- Evidence: `no host-published ports`
+- Recommendation: Confirm this matches the intended access path and document any proxy, VPN, or firewall assumptions.
 
-This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.
+No host-published Compose ports were detected. This is not proof that the service is impossible to reach.
 
 ## Service Details
 
 ### traefik
 
-Classification: **directly exposed**
+Looks like: **published**
+
+Why: ports: 80:80, ports: 443:443
 
 Ports:
 
-- `80:80` (broad/public)
-- `443:443` (broad/public)
+- `80:80`
+- `443:443`
 
 Findings:
 
@@ -54,7 +56,9 @@ No service-specific findings.
 
 ### web
 
-Classification: **reverse-proxy exposed**
+Looks like: **unknown**
+
+Why: proxy labels detected; note only in MVP
 
 Ports:
 
@@ -62,71 +66,63 @@ Ports:
 
 Findings:
 
-No service-specific findings.
+### Service exposure is unknown
+
+- Level: medium
+- Service: `web`
+- Rule: `unknown-exposure`
+- Evidence: `proxy labels detected; note only in MVP`
+- Recommendation: Review this service manually, including reverse proxy, VPN, firewall, and host-level configuration.
+
+ExposeMap could not confidently classify this service from Compose configuration alone.
 
 ### postgres
 
-Classification: **directly exposed**
+Looks like: **published**
+
+Why: ports: 5432:5432
 
 Ports:
 
-- `5432:5432` (broad/public)
+- `5432:5432`
 
 Findings:
 
-### PostgreSQL appears directly exposed
-
-- Severity: high
-- Service: `postgres`
-- Rule: `risky-direct-port`
-- Evidence: `5432:5432`
-- Recommendation: Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path.
-
-This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.
+No service-specific findings.
 
 ### redis
 
-Classification: **directly exposed**
+Looks like: **published**
+
+Why: ports: 0.0.0.0:6379:6379
 
 Ports:
 
-- `0.0.0.0:6379:6379` (broad/public)
+- `0.0.0.0:6379:6379`
 
 Findings:
 
-### Redis appears directly exposed
-
-- Severity: high
-- Service: `redis`
-- Rule: `risky-direct-port`
-- Evidence: `0.0.0.0:6379:6379`
-- Recommendation: Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path.
-
-This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.
+No service-specific findings.
 
 ### admin
 
-Classification: **localhost-only**
+Looks like: **published**
+
+Why: ports: 127.0.0.1:8080:8080
 
 Ports:
 
-- `127.0.0.1:8080:8080` (localhost-only)
+- `127.0.0.1:8080:8080`
 
 Findings:
 
-### Service is localhost-only
-
-- Severity: low
-- Service: `admin`
-- Rule: `localhost-only`
-- Evidence: `127.0.0.1:8080:8080`
-- Recommendation: Keep this pattern for admin tools and databases unless broader access is intentional.
-
-All parsed port mappings are bound to localhost.
+No service-specific findings.
 
 ### worker
 
-Classification: **internal**
+Looks like: **internal**
+
+Why: no host-published ports
 
 Ports:
 
@@ -136,27 +132,27 @@ Findings:
 
 ### Service appears internal
 
-- Severity: low
+- Level: low
 - Service: `worker`
 - Rule: `internal-service`
-- Evidence: `worker`
-- Recommendation: Confirm this matches the intended access path and document any VPN or proxy assumptions.
+- Evidence: `no host-published ports`
+- Recommendation: Confirm this matches the intended access path and document any proxy, VPN, or firewall assumptions.
 
-No Compose port mappings or reverse proxy routing labels were detected.
+No host-published Compose ports were detected. This is not proof that the service is impossible to reach.
 
 ## Mermaid Diagram
 
 ```mermaid
 graph TD
-  Internet[Internet]
-  Localhost[Localhost]
-  InternalNetwork[Internal network]
-  Internet --> svc_traefik[traefik]
-  svc_traefik --> svc_web[web]
-  Internet --> svc_postgres[postgres]
-  Internet --> svc_redis[redis]
-  Localhost --> svc_admin[admin]
-  InternalNetwork --> svc_worker[worker]
+  Published[Host-published in Compose]
+  Internal[No host-published ports found]
+  Unknown[Unknown from Compose]
+  Published --> svc_traefik[traefik]
+  Published --> svc_postgres[postgres]
+  Published --> svc_redis[redis]
+  Published --> svc_admin[admin]
+  Internal --> svc_worker[worker]
+  Unknown -.-> svc_web[web]
   svc_web --> svc_postgres[postgres]
   svc_web --> svc_redis[redis]
   svc_worker --> svc_redis[redis]
@@ -166,7 +162,14 @@ graph TD
 
 - ExposeMap is a lightweight, read-only configuration review tool.
 - Results are heuristic checks based on Docker Compose configuration.
-- ExposeMap does not prove real internet exposure.
+- published means host-published in Compose, not internet-reachable.
+- internal means no host-published ports found, not impossible to reach.
 - ExposeMap does not perform real network scans.
 - ExposeMap does not connect to containers or modify Compose files.
 - Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure.
+
+```text
+ExposeMap reads local Compose configuration only.
+It does not test live reachability, firewall, DNS, VPN, tunnels, cloud security groups, or vulnerabilities.
+Do not paste real Compose files or secrets into public issues. Use sanitized examples only.
+```

--- a/examples/report.md
+++ b/examples/report.md
@@ -167,9 +167,11 @@ graph TD
 - ExposeMap does not perform real network scans.
 - ExposeMap does not connect to containers or modify Compose files.
 - Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure.
+- Some Compose features, such as profiles, extends, include, anchors, merge keys, or variable interpolation, may require expanded Compose config for safer review.
 
 ```text
 ExposeMap reads local Compose configuration only.
 It does not test live reachability, firewall, DNS, VPN, tunnels, cloud security groups, or vulnerabilities.
 Do not paste real Compose files or secrets into public issues. Use sanitized examples only.
+Some Compose features, such as profiles, extends, include, anchors, merge keys, or variable interpolation, may require expanded Compose config for safer review.
 ```

--- a/launch/medium-article.md
+++ b/launch/medium-article.md
@@ -34,11 +34,11 @@ ExposeMap parses Docker Compose configuration and reports exposure hints such as
 
 - internal
 - localhost-only
-- directly exposed from Compose config
-- reverse-proxy exposed
+- directly published in Compose config
+- likely reverse-proxy exposed from Compose labels
 - unknown
 
-It looks at common port mappings, localhost bindings, broad host bindings, Traefik-style labels, likely reverse proxy services, and directly published database, cache, search, or admin ports that deserve review.
+It looks at common port mappings, localhost bindings, broad host bindings, Traefik-style labels, likely reverse proxy services, and directly published database, cache, search, or admin ports that may deserve review.
 
 It also generates a Mermaid diagram so the likely exposure paths are easier to discuss in issues, pull requests, and internal reviews.
 

--- a/launch/medium-article.md
+++ b/launch/medium-article.md
@@ -1,59 +1,98 @@
-# How to see what your self-hosted Docker Compose stack exposes
-
-Self-hosted Docker Compose stacks often become difficult to reason about over time. A setup may start with one app and one database, then grow into a mix of admin panels, reverse proxies, caches, dashboards, VPNs, tunnels, and old experiments.
-
-Eventually, a simple question becomes surprisingly hard to answer: which services are reachable, and how?
-
-## Why exposure gets confusing
-
-Compose exposure often depends on small details. `5432:5432` and `127.0.0.1:5432:5432` are not equivalent. A service with no `ports` entry may still be routed through Traefik. A reverse proxy may rely on mounted config or external state that is not obvious from the Compose file alone.
-
-This does not mean Compose can prove real internet exposure. Firewalls, cloud security groups, DNS, VPNs, and host-level rules all matter. But Compose can still provide useful signals.
-
-## Directly exposing databases
-
-Database ports such as PostgreSQL `5432`, MySQL `3306`, Redis `6379`, MongoDB `27017`, and Elasticsearch/OpenSearch `9200` are worth reviewing carefully when they are published broadly.
-
-```yaml
-services:
-  postgres:
-    image: postgres:16
-    ports:
-      - "5432:5432"
-```
-
-For many stacks, localhost-only binding or no host port mapping is a safer default.
-
-## Localhost-only is different from broad binding
-
-These are easy to confuse:
-
-```yaml
-ports:
-  - "8080:8080"
-```
-
-```yaml
-ports:
-  - "127.0.0.1:8080:8080"
-```
-
-The first publishes broadly. The second binds to localhost. In a large Compose file, this difference is easy to miss.
-
-## Reverse proxies still need review
-
-Reverse proxies are useful, but they are not magic. Traefik labels, Caddyfiles, Nginx Proxy Manager state, host firewall rules, and VPN routing can all affect the real exposure path.
-
-Compose can show hints, but it cannot replace a full review.
-
-## Why I built ExposeMap
-
-I built ExposeMap as a small open-source CLI for self-hosted Docker Compose stacks.
-
-It scans `docker-compose.yml` and classifies services as internal, localhost-only, directly exposed, reverse-proxy exposed, or unknown. It generates a Markdown report and a Mermaid diagram so you can quickly see likely exposure paths.
-
-ExposeMap runs locally. It does not modify Compose files, connect to containers, send reports anywhere, or perform real network scans.
+# Why I made a small Docker Compose exposure mapper open source
 
 GitHub: https://github.com/kaibuild/exposemap
 
-Technical feedback and sanitized Compose edge cases are welcome.
+I built ExposeMap because self-hosted Docker Compose stacks often become hard to reason about after a few months of real use.
+
+A Compose file may start with one app and one database. Later it has a reverse proxy, a dashboard, Redis, a monitoring service, a tunnel, a VPN, a few temporary admin panels, and old port mappings that were added during debugging and never removed.
+
+At that point, the useful question is not dramatic:
+
+Which services appear published, proxied, localhost-only, internal, or unclear from this Compose file?
+
+That is the narrow problem ExposeMap tries to solve.
+
+## Why this should be local first
+
+Compose files can contain sensitive infrastructure details: service names, internal hostnames, labels, image names, mounted paths, ports, and sometimes secrets that should not have been committed.
+
+For this kind of review tool, a hosted-first workflow would be the wrong default. I do not want people uploading private Compose files just to get a first-pass exposure map.
+
+ExposeMap is intentionally local and read-only:
+
+- it reads the Compose file you point it at
+- it does not upload Compose files or reports
+- it does not connect to containers
+- it does not modify infrastructure
+- it does not run live network scans
+
+The output is a Markdown or JSON report you can inspect yourself, share internally, or run in CI.
+
+## What it actually checks
+
+ExposeMap parses Docker Compose configuration and reports exposure hints such as:
+
+- internal
+- localhost-only
+- directly exposed from Compose config
+- reverse-proxy exposed
+- unknown
+
+It looks at common port mappings, localhost bindings, broad host bindings, Traefik-style labels, likely reverse proxy services, and directly published database, cache, search, or admin ports that deserve review.
+
+It also generates a Mermaid diagram so the likely exposure paths are easier to discuss in issues, pull requests, and internal reviews.
+
+## What it does not prove
+
+This is important: ExposeMap does not prove real internet reachability.
+
+Firewalls, cloud security groups, VPNs, tunnels, DNS, reverse proxies, and host rules can all change what is actually reachable. A Compose file is only one source of truth.
+
+So ExposeMap should be treated as a first-pass configuration review tool, not a security audit and not a vulnerability scanner.
+
+The goal is to make suspicious or confusing Compose exposure hints visible enough that a human can review them.
+
+## Why open source matters here
+
+I made it open source because the hard part is not just code. The hard part is edge cases.
+
+Self-hosted Compose setups vary a lot. People use different reverse proxies, different label conventions, different bind patterns, different admin tools, and different ways of separating internal and external services.
+
+If the tool is public, people can inspect the assumptions instead of trusting a black box. They can also point out where the wording is too strong, where a classification is misleading, or where a common Compose pattern is missing.
+
+That feedback loop is the main reason this project belongs on GitHub.
+
+## What I would like feedback on
+
+The most useful feedback right now is practical and specific:
+
+- sanitized Compose examples that are classified poorly
+- false positives around reverse proxy labels
+- false negatives around broad port publishing
+- wording that sounds too certain
+- report output that would be clearer in a pull request or CI job
+
+I am especially interested in examples that make the classification more honest, not more dramatic.
+
+## How to try it
+
+Clone the repo, install dependencies, build it, and run a scan against a Compose file:
+
+```bash
+npm install
+npm run build
+node dist/cli.js scan ./docker-compose.yml --format markdown
+```
+
+Docker usage is also supported:
+
+```bash
+docker build -t exposemap .
+docker run --rm -v $(pwd):/scan exposemap scan /scan/docker-compose.yml --format markdown
+```
+
+The README includes example output, Docker usage, JSON output, CI usage, exit codes, limitations, and a roadmap.
+
+GitHub: https://github.com/kaibuild/exposemap
+
+If you self-host with Docker Compose and have a sanitized edge case that ExposeMap should handle better, that is the kind of feedback I am looking for.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "scan:example": "node dist/cli.js scan examples/risky-compose.yml --format markdown"
+    "scan:example": "node dist/cli.js scan examples/risky-compose.yml --format table"
   },
   "keywords": [
     "docker",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,10 +4,11 @@ import { getExitCodeForReport, parseFailOnThreshold } from "./failOn.js";
 import { scanComposeFile } from "./index.js";
 import { renderJsonReport } from "./report/json.js";
 import { renderMarkdownReport } from "./report/markdown.js";
+import { renderTableReport } from "./report/table.js";
 import { getToolVersion } from "./version.js";
 
 const program = new Command();
-const supportedFormats = new Set(["markdown", "json"]);
+const supportedFormats = new Set(["table", "markdown", "json"]);
 
 program
   .name("exposemap")
@@ -18,7 +19,7 @@ program
 program
   .command("scan")
   .argument("<compose-file>", "Path to docker-compose.yml")
-  .option("--format <format>", "Report format: markdown or json", "markdown")
+  .option("--format <format>", "Report format: table, markdown, or json", "table")
   .option("--fail-on <severity>", "Exit 1 on findings at or above severity: high, medium, low, none", "none")
   .description("Scan a Docker Compose file and print an exposure report")
   .action(async (composeFile: string, options: { format: string; failOn: string }) => {
@@ -26,7 +27,7 @@ program
     const failOn = parseFailOnThreshold(options.failOn.toLowerCase());
 
     if (!supportedFormats.has(format)) {
-      console.error(`Unsupported format: ${options.format}. Supported formats: markdown, json.`);
+      console.error(`Unsupported format: ${options.format}. Supported formats: table, markdown, json.`);
       process.exitCode = 2;
       return;
     }
@@ -39,13 +40,14 @@ program
 
     try {
       const report = await scanComposeFile(composeFile);
-      const output = format === "json" ? renderJsonReport(report) : renderMarkdownReport(report);
+      const output =
+        format === "json" ? renderJsonReport(report) : format === "markdown" ? renderMarkdownReport(report) : renderTableReport(report);
       process.stdout.write(output);
       process.exitCode = getExitCodeForReport(report, failOn);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(`ExposeMap failed: ${message}`);
-      process.exitCode = 2;
+      process.exitCode = 1;
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { parseComposeFile } from "./parser.js";
 import { analyzeProject } from "./rules/serviceClassifier.js";
 import { renderJsonReport } from "./report/json.js";
 import { renderMarkdownReport } from "./report/markdown.js";
+import { renderTableReport } from "./report/table.js";
 import type { ExposureReport } from "./types.js";
 
 export async function scanComposeFile(filePath: string): Promise<ExposureReport> {
@@ -19,10 +20,16 @@ export async function scanComposeFileToJson(filePath: string): Promise<string> {
   return renderJsonReport(report);
 }
 
+export async function scanComposeFileToTable(filePath: string): Promise<string> {
+  const report = await scanComposeFile(filePath);
+  return renderTableReport(report);
+}
+
 export * from "./types.js";
 export { parseComposeContent, parseComposeFile } from "./parser.js";
 export { analyzeProject, analyzeService } from "./rules/serviceClassifier.js";
 export { parseFailOnThreshold, getExitCodeForReport, violatesFailOnThreshold } from "./failOn.js";
 export { buildJsonReport, renderJsonReport } from "./report/json.js";
 export { renderMarkdownReport } from "./report/markdown.js";
+export { renderTableReport } from "./report/table.js";
 export { renderMermaidDiagram } from "./report/mermaid.js";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -27,6 +27,7 @@ export function parseComposeContent(content: string, filePath = "<memory>"): Com
       name,
       image: typeof value.image === "string" ? value.image : undefined,
       ports: Array.isArray(value.ports) ? value.ports : [],
+      expose: normalizeList(value.expose),
       labels: normalizeKeyValueList(value.labels),
       environment: normalizeKeyValueList(value.environment),
       dependsOn: normalizeDependsOn(value.depends_on),
@@ -35,6 +36,14 @@ export function parseComposeContent(content: string, filePath = "<memory>"): Com
   });
 
   return { filePath, services };
+}
+
+function normalizeList(value: unknown): unknown[] {
+  if (!value) {
+    return [];
+  }
+
+  return Array.isArray(value) ? value : [value];
 }
 
 function normalizeKeyValueList(value: unknown): Record<string, string> {

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -1,5 +1,6 @@
 import type { ExposureClassification, ExposureReport, Finding, PortMapping, ServiceAnalysis } from "../types.js";
 import { TOOL_NAME, getToolVersion } from "../version.js";
+import { REPORT_WARNING_LINES } from "../warnings.js";
 
 interface JsonSummary {
   totalServices: number;
@@ -47,6 +48,7 @@ export interface JsonExposureReport {
   };
   scannedFilePath: string;
   generatedAt: string;
+  disclaimers: string[];
   summary: JsonSummary;
   services: JsonService[];
   exposureMap: JsonExposureMapEntry[];
@@ -62,6 +64,7 @@ export function buildJsonReport(report: ExposureReport): JsonExposureReport {
     },
     scannedFilePath: report.filePath,
     generatedAt: report.generatedAt,
+    disclaimers: REPORT_WARNING_LINES,
     summary: buildSummary(report),
     services: report.services.map(buildService),
     exposureMap: report.services.map(buildExposureMapEntry),

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -4,9 +4,7 @@ import { TOOL_NAME, getToolVersion } from "../version.js";
 interface JsonSummary {
   totalServices: number;
   internal: number;
-  localhostOnly: number;
-  directlyExposed: number;
-  reverseProxyExposed: number;
+  published: number;
   unknown: number;
   totalFindings: number;
   high: number;
@@ -17,6 +15,7 @@ interface JsonSummary {
 interface JsonService {
   name: string;
   classification: ExposureClassification;
+  why: string;
   image?: string;
   ports: JsonPort[];
   labels: Record<string, string>;
@@ -79,9 +78,7 @@ function buildSummary(report: ExposureReport): JsonSummary {
   return {
     totalServices: report.services.length,
     internal: countServices(report, "internal"),
-    localhostOnly: countServices(report, "localhost-only"),
-    directlyExposed: countServices(report, "directly exposed"),
-    reverseProxyExposed: countServices(report, "reverse-proxy exposed"),
+    published: countServices(report, "published"),
     unknown: countServices(report, "unknown"),
     totalFindings: report.findings.length,
     high: countFindings(report, "high"),
@@ -94,6 +91,7 @@ function buildService(service: ServiceAnalysis): JsonService {
   return {
     name: service.service.name,
     classification: service.classification,
+    why: service.why,
     image: service.service.image,
     ports: service.ports.map(buildPort),
     labels: service.service.labels,
@@ -127,11 +125,11 @@ function buildEvidence(service: ServiceAnalysis): string[] {
   const evidence = service.ports.map((port) => port.evidence);
 
   if (service.isReverseProxy) {
-    evidence.push("likely reverse proxy service");
+    evidence.push("likely reverse proxy service; note only in MVP");
   }
 
   if (service.hasReverseProxyRouting) {
-    evidence.push("reverse proxy routing labels/env detected");
+    evidence.push("proxy labels detected; note only in MVP");
   }
 
   if (service.ports.length === 0) {
@@ -143,14 +141,10 @@ function buildEvidence(service: ServiceAnalysis): string[] {
 
 function getEntrypoints(service: ServiceAnalysis): string[] {
   switch (service.classification) {
-    case "directly exposed":
-      return ["internet"];
-    case "localhost-only":
-      return ["localhost"];
-    case "reverse-proxy exposed":
-      return ["reverse-proxy"];
+    case "published":
+      return ["host-published-in-compose"];
     case "internal":
-      return ["internal-network"];
+      return ["no-host-published-ports-found"];
     case "unknown":
       return ["unknown"];
   }

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -1,8 +1,7 @@
 import type { ExposureReport, Finding, ServiceAnalysis } from "../types.js";
+import { CONFIGURATION_ONLY_WARNING } from "../warnings.js";
 
 export function renderMarkdownReport(report: ExposureReport): string {
-  const highRiskFindings = report.findings.filter((finding) => finding.severity === "high");
-
   return [
     "# ExposeMap Report",
     "",
@@ -10,13 +9,13 @@ export function renderMarkdownReport(report: ExposureReport): string {
     "",
     `Total services: ${report.services.length}`,
     "",
-    "## Exposure Summary",
+    "## Compose Visibility Summary",
     "",
     renderSummaryTable(report.services),
     "",
-    "## High-risk Findings",
+    "## Review Notes",
     "",
-    renderFindings(highRiskFindings, "No high-risk findings detected from Compose configuration."),
+    renderFindings(report.findings, "No review notes detected from Compose configuration."),
     "",
     "## Service Details",
     "",
@@ -32,28 +31,27 @@ export function renderMarkdownReport(report: ExposureReport): string {
     "",
     "- ExposeMap is a lightweight, read-only configuration review tool.",
     "- Results are heuristic checks based on Docker Compose configuration.",
-    "- ExposeMap does not prove real internet exposure.",
+    "- published means host-published in Compose, not internet-reachable.",
+    "- internal means no host-published ports found, not impossible to reach.",
     "- ExposeMap does not perform real network scans.",
     "- ExposeMap does not connect to containers or modify Compose files.",
     "- Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure.",
+    "",
+    "```text",
+    CONFIGURATION_ONLY_WARNING,
+    "```",
     ""
   ].join("\n");
 }
 
 function renderSummaryTable(services: ServiceAnalysis[]): string {
   return [
-    "| Service | Classification | Ports | Reverse proxy hints |",
+    "| Service | Looks like | Why | Notes |",
     "| --- | --- | --- | --- |",
     ...services.map((service) => {
-      const ports = service.ports.map((port) => `\`${port.evidence}\``).join("<br>") || "-";
-      const reverseProxyHints = [
-        service.isReverseProxy ? "proxy service" : "",
-        service.hasReverseProxyRouting ? "routing labels/env" : ""
-      ]
-        .filter(Boolean)
-        .join(", ");
+      const notes = service.notes.join("<br>") || "-";
 
-      return `| ${service.service.name} | ${service.classification} | ${ports} | ${reverseProxyHints || "-"} |`;
+      return `| ${service.service.name} | ${service.classification} | ${service.why} | ${notes} |`;
     })
   ].join("\n");
 }
@@ -68,7 +66,7 @@ function renderFindings(findings: Finding[], emptyMessage: string): string {
       (finding) => [
         `### ${finding.title}`,
         "",
-        `- Severity: ${finding.severity}`,
+        `- Level: ${finding.severity}`,
         `- Service: \`${finding.service}\``,
         `- Rule: \`${finding.ruleId}\``,
         `- Evidence: \`${finding.evidence}\``,
@@ -85,18 +83,15 @@ function renderServiceDetails(service: ServiceAnalysis): string {
     ? renderFindings(service.findings, "")
     : "No service-specific findings.";
   const ports = service.ports.length
-    ? service.ports
-        .map((port) => {
-          const binding = port.isLocalhostBound ? "localhost-only" : "broad/public";
-          return `- \`${port.evidence}\` (${binding})`;
-        })
-        .join("\n")
+    ? service.ports.map((port) => `- \`${port.evidence}\``).join("\n")
     : "- No Compose `ports` entries detected.";
 
   return [
     `### ${service.service.name}`,
     "",
-    `Classification: **${service.classification}**`,
+    `Looks like: **${service.classification}**`,
+    "",
+    `Why: ${service.why}`,
     "",
     "Ports:",
     "",

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -1,5 +1,9 @@
 import type { ExposureReport, Finding, ServiceAnalysis } from "../types.js";
-import { CONFIGURATION_ONLY_WARNING } from "../warnings.js";
+import {
+  CLASSIFICATION_WARNING_LINES,
+  CONFIGURATION_ONLY_WARNING,
+  STATIC_COMPOSE_LIMITATION_WARNING
+} from "../warnings.js";
 
 export function renderMarkdownReport(report: ExposureReport): string {
   return [
@@ -31,14 +35,15 @@ export function renderMarkdownReport(report: ExposureReport): string {
     "",
     "- ExposeMap is a lightweight, read-only configuration review tool.",
     "- Results are heuristic checks based on Docker Compose configuration.",
-    "- published means host-published in Compose, not internet-reachable.",
-    "- internal means no host-published ports found, not impossible to reach.",
+    ...CLASSIFICATION_WARNING_LINES.map((warning) => `- ${warning}`),
     "- ExposeMap does not perform real network scans.",
     "- ExposeMap does not connect to containers or modify Compose files.",
     "- Reverse proxy, firewall, VPN, DNS, cloud security group, and host-level rules can change real exposure.",
+    `- ${STATIC_COMPOSE_LIMITATION_WARNING}`,
     "",
     "```text",
     CONFIGURATION_ONLY_WARNING,
+    STATIC_COMPOSE_LIMITATION_WARNING,
     "```",
     ""
   ].join("\n");

--- a/src/report/mermaid.ts
+++ b/src/report/mermaid.ts
@@ -2,45 +2,24 @@ import type { ServiceAnalysis } from "../types.js";
 
 export function renderMermaidDiagram(services: ServiceAnalysis[]): string {
   const lines = ["graph TD"];
-  const reverseProxies = services.filter((service) => service.isReverseProxy);
-  const routedServices = services.filter((service) => service.hasReverseProxyRouting && !service.isReverseProxy);
-  const directlyExposed = services.filter(
-    (service) => service.classification === "directly exposed" && !service.isReverseProxy
-  );
+  const published = services.filter((service) => service.classification === "published");
   const internal = services.filter((service) => service.classification === "internal");
-  const localhostOnly = services.filter((service) => service.classification === "localhost-only");
   const unknown = services.filter((service) => service.classification === "unknown");
 
-  lines.push("  Internet[Internet]");
-  lines.push("  Localhost[Localhost]");
-  lines.push("  InternalNetwork[Internal network]");
+  lines.push("  Published[Host-published in Compose]");
+  lines.push("  Internal[No host-published ports found]");
+  lines.push("  Unknown[Unknown from Compose]");
 
-  if (reverseProxies.length > 0) {
-    for (const proxy of reverseProxies) {
-      lines.push(`  Internet --> ${nodeId(proxy.service.name)}[${escapeLabel(proxy.service.name)}]`);
-    }
-
-    for (const proxy of reverseProxies) {
-      for (const service of routedServices) {
-        lines.push(`  ${nodeId(proxy.service.name)} --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
-      }
-    }
-  }
-
-  for (const service of directlyExposed) {
-    lines.push(`  Internet --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
-  }
-
-  for (const service of localhostOnly) {
-    lines.push(`  Localhost --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
+  for (const service of published) {
+    lines.push(`  Published --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
   }
 
   for (const service of internal) {
-    lines.push(`  InternalNetwork --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
+    lines.push(`  Internal --> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
   }
 
   for (const service of unknown) {
-    lines.push(`  Unknown[Unknown exposure] -.-> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
+    lines.push(`  Unknown -.-> ${nodeId(service.service.name)}[${escapeLabel(service.service.name)}]`);
   }
 
   addDependencyEdges(lines, services);

--- a/src/report/table.ts
+++ b/src/report/table.ts
@@ -1,5 +1,9 @@
 import type { ExposureReport } from "../types.js";
-import { CONFIGURATION_ONLY_WARNING } from "../warnings.js";
+import {
+  CLASSIFICATION_WARNING_LINES,
+  CONFIGURATION_ONLY_WARNING,
+  STATIC_COMPOSE_LIMITATION_WARNING
+} from "../warnings.js";
 
 export function renderTableReport(report: ExposureReport): string {
   const rows = [
@@ -11,10 +15,10 @@ export function renderTableReport(report: ExposureReport): string {
   return [
     rows.map((row) => row.map((cell, column) => cell.padEnd(widths[column])).join("   ")).join("\n"),
     "",
-    "published means host-published in Compose, not internet-reachable.",
-    "internal means no host-published ports found, not impossible to reach.",
+    ...CLASSIFICATION_WARNING_LINES,
     "",
     CONFIGURATION_ONLY_WARNING,
+    STATIC_COMPOSE_LIMITATION_WARNING,
     ""
   ].join("\n");
 }

--- a/src/report/table.ts
+++ b/src/report/table.ts
@@ -1,0 +1,20 @@
+import type { ExposureReport } from "../types.js";
+import { CONFIGURATION_ONLY_WARNING } from "../warnings.js";
+
+export function renderTableReport(report: ExposureReport): string {
+  const rows = [
+    ["Service", "Looks like", "Why"],
+    ...report.services.map((service) => [service.service.name, service.classification, service.why])
+  ];
+  const widths = rows[0].map((_, column) => Math.max(...rows.map((row) => row[column].length)));
+
+  return [
+    rows.map((row) => row.map((cell, column) => cell.padEnd(widths[column])).join("   ")).join("\n"),
+    "",
+    "published means host-published in Compose, not internet-reachable.",
+    "internal means no host-published ports found, not impossible to reach.",
+    "",
+    CONFIGURATION_ONLY_WARNING,
+    ""
+  ].join("\n");
+}

--- a/src/rules/ports.ts
+++ b/src/rules/ports.ts
@@ -34,12 +34,16 @@ export function isLocalhostBinding(hostIp: string | undefined): boolean {
 
 function parseShortPort(raw: string): PortMapping | null {
   const trimmed = raw.trim();
-  if (!trimmed) {
+  if (!trimmed || hasInterpolation(trimmed)) {
     return null;
   }
 
   const [withoutProtocol, protocol] = splitProtocol(trimmed);
   const parts = withoutProtocol.split(":");
+
+  if (parts.some((part) => part.trim().length === 0)) {
+    return null;
+  }
 
   if (parts.length === 1) {
     return buildPortMapping({
@@ -83,7 +87,7 @@ function parseLongPort(raw: Record<string, unknown>): PortMapping | null {
   const hostIp = typeof raw.host_ip === "string" ? raw.host_ip : undefined;
   const protocol = typeof raw.protocol === "string" ? raw.protocol : undefined;
 
-  if (!target && !published) {
+  if ((!target && !published) || hasInterpolation(target) || hasInterpolation(published) || hasInterpolation(hostIp)) {
     return null;
   }
 
@@ -97,6 +101,10 @@ function parseLongPort(raw: Record<string, unknown>): PortMapping | null {
     protocol,
     isPublished: true
   });
+}
+
+function hasInterpolation(value: string | undefined): boolean {
+  return Boolean(value?.includes("$"));
 }
 
 function buildPortMapping(input: Omit<PortMapping, "isLocalhostBound" | "isBroadlyBound">): PortMapping {

--- a/src/rules/riskyServices.ts
+++ b/src/rules/riskyServices.ts
@@ -29,12 +29,12 @@ export function findRiskyDirectExposure(serviceName: string, broadPorts: PortMap
         ruleId: "risky-direct-port",
         severity: "high",
         service: serviceName,
-        title: `${matched.name} appears directly exposed`,
+        title: `${matched.name} has a host-published Compose port`,
         description:
-          "This service publishes a port commonly associated with databases, search backends, caches, or admin panels without a localhost-only binding.",
+          "This service has a host-published Compose port commonly associated with databases, search backends, caches, or admin panels.",
         evidence: port.evidence,
         recommendation:
-          "Bind the port to localhost, remove the public port mapping, or place the service behind an intentionally configured reverse proxy/VPN path."
+          "Review whether this host-published Compose port is intentional. Real reachability still depends on firewall, VPN, proxy, DNS, cloud security group, and host rules."
       }
     ];
   });

--- a/src/rules/serviceClassifier.ts
+++ b/src/rules/serviceClassifier.ts
@@ -10,7 +10,6 @@ import { getBroadlyBoundPorts } from "./directExposure.js";
 import { getLocalhostBindings } from "./localhostBindings.js";
 import { parsePortMappings } from "./ports.js";
 import { hasReverseProxyRoutingHint, isLikelyReverseProxyService } from "./reverseProxy.js";
-import { findRiskyDirectExposure } from "./riskyServices.js";
 import { renderMermaidDiagram } from "../report/mermaid.js";
 
 export function analyzeProject(project: ComposeProject): ExposureReport {
@@ -34,19 +33,15 @@ export function analyzeService(service: ComposeService): ServiceAnalysis {
   const localhostPorts = getLocalhostBindings(ports);
   const isReverseProxy = isLikelyReverseProxyService(service);
   const hasReverseProxyRouting = hasReverseProxyRoutingHint(service);
-  const notes: string[] = [];
   const classification = classifyService({
     ports,
-    broadPorts,
-    localhostPorts,
     hasReverseProxyRouting,
     service
   });
+  const why = buildWhy(service, ports, classification, hasReverseProxyRouting);
+  const notes = buildNotes(service, ports, hasReverseProxyRouting);
 
-  const findings: Finding[] = [
-    ...findRiskyDirectExposure(service.name, broadPorts),
-    ...buildInformationalFindings(service.name, classification, localhostPorts)
-  ];
+  const findings: Finding[] = buildInformationalFindings(service.name, classification, why);
 
   if (ports.length !== service.ports.length) {
     findings.push({
@@ -58,7 +53,6 @@ export function analyzeService(service: ComposeService): ServiceAnalysis {
       evidence: JSON.stringify(service.ports),
       recommendation: "Review this service manually and consider opening an issue with a sanitized Compose snippet."
     });
-    notes.push("One or more port mappings could not be parsed.");
   }
 
   return {
@@ -69,6 +63,7 @@ export function analyzeService(service: ComposeService): ServiceAnalysis {
     localhostPorts,
     isReverseProxy,
     hasReverseProxyRouting,
+    why,
     findings,
     notes
   };
@@ -76,8 +71,6 @@ export function analyzeService(service: ComposeService): ServiceAnalysis {
 
 function classifyService(input: {
   ports: ReturnType<typeof parsePortMappings>;
-  broadPorts: ReturnType<typeof getBroadlyBoundPorts>;
-  localhostPorts: ReturnType<typeof getLocalhostBindings>;
   hasReverseProxyRouting: boolean;
   service: ComposeService;
 }): ExposureClassification {
@@ -85,30 +78,81 @@ function classifyService(input: {
     return "unknown";
   }
 
-  if (input.broadPorts.length > 0) {
-    return "directly exposed";
-  }
-
-  if (input.ports.length > 0 && input.localhostPorts.length === input.ports.length) {
-    return "localhost-only";
+  if (input.ports.length > 0) {
+    return "published";
   }
 
   if (input.hasReverseProxyRouting) {
-    return "reverse-proxy exposed";
+    return "unknown";
   }
 
-  if (input.ports.length === 0 && !input.hasReverseProxyRouting) {
-    return "internal";
-  }
-
-  return "unknown";
+  return "internal";
 }
 
-function buildInformationalFindings(
-  serviceName: string,
+function buildWhy(
+  service: ComposeService,
+  ports: ReturnType<typeof parsePortMappings>,
   classification: ExposureClassification,
-  localhostPorts: ReturnType<typeof getLocalhostBindings>
-): Finding[] {
+  hasReverseProxyRouting: boolean
+): string {
+  if (classification === "published") {
+    return ports.map((port) => `ports: ${port.evidence}`).join(", ");
+  }
+
+  if (classification === "unknown") {
+    if (service.ports.length > 0 && ports.length !== service.ports.length) {
+      return "requires expanded compose config";
+    }
+
+    if (hasReverseProxyRouting) {
+      return "proxy labels detected; note only in MVP";
+    }
+
+    return "unsupported compose syntax";
+  }
+
+  if (service.expose.length > 0) {
+    return `expose only: ${service.expose.map(String).join(", ")}`;
+  }
+
+  if (hasServiceNetworks(service.raw.networks)) {
+    return "no host-published ports; attached to service networks";
+  }
+
+  return "no host-published ports";
+}
+
+function hasServiceNetworks(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return typeof value === "object" && value !== null && Object.keys(value).length > 0;
+}
+
+function buildNotes(
+  service: ComposeService,
+  ports: ReturnType<typeof parsePortMappings>,
+  hasReverseProxyRouting: boolean
+): string[] {
+  const notes: string[] = [];
+
+  if (ports.some((port) => port.isLocalhostBound)) {
+    notes.push("Host binding is local, but MVP still reports host-published ports as published.");
+  }
+
+  if (hasReverseProxyRouting) {
+    notes.push("Reverse proxy labels are note only in MVP and are not a formal classification.");
+  }
+
+  if (service.ports.length > 0 && ports.length !== service.ports.length) {
+    notes.push("One or more port mappings could not be parsed.");
+  }
+
+  return notes;
+}
+
+function buildInformationalFindings(serviceName: string, classification: ExposureClassification, why: string): Finding[] {
   if (classification === "unknown") {
     return [
       {
@@ -117,22 +161,8 @@ function buildInformationalFindings(
         service: serviceName,
         title: "Service exposure is unknown",
         description: "ExposeMap could not confidently classify this service from Compose configuration alone.",
-        evidence: serviceName,
+        evidence: why,
         recommendation: "Review this service manually, including reverse proxy, VPN, firewall, and host-level configuration."
-      }
-    ];
-  }
-
-  if (classification === "localhost-only") {
-    return [
-      {
-        ruleId: "localhost-only",
-        severity: "low",
-        service: serviceName,
-        title: "Service is localhost-only",
-        description: "All parsed port mappings are bound to localhost.",
-        evidence: localhostPorts.map((port) => port.evidence).join(", "),
-        recommendation: "Keep this pattern for admin tools and databases unless broader access is intentional."
       }
     ];
   }
@@ -144,9 +174,10 @@ function buildInformationalFindings(
         severity: "low",
         service: serviceName,
         title: "Service appears internal",
-        description: "No Compose port mappings or reverse proxy routing labels were detected.",
-        evidence: serviceName,
-        recommendation: "Confirm this matches the intended access path and document any VPN or proxy assumptions."
+        description:
+          "No host-published Compose ports were detected. This is not proof that the service is impossible to reach.",
+        evidence: why,
+        recommendation: "Confirm this matches the intended access path and document any proxy, VPN, or firewall assumptions."
       }
     ];
   }
@@ -164,9 +195,9 @@ function addReverseProxyClarityFindings(analyses: ServiceAnalysis[], findings: F
         ruleId: "reverse-proxy-routes-unclear",
         severity: "medium",
         service: reverseProxy.service.name,
-        title: "Reverse proxy service detected but routed services are unclear",
+        title: "Reverse proxy service hint detected",
         description:
-          "A likely reverse proxy service exists, but ExposeMap did not find obvious routing labels on application services.",
+          "A likely reverse proxy service exists. Reverse proxy behavior is note-only in the MVP and is not a formal classification.",
         evidence: reverseProxy.service.image ?? reverseProxy.service.name,
         recommendation:
           "Review reverse proxy configuration outside Compose, such as mounted Caddyfiles, Nginx Proxy Manager state, Traefik dynamic config, or host files."

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,6 @@
 export type ExposureClassification =
   | "internal"
-  | "localhost-only"
-  | "directly exposed"
-  | "reverse-proxy exposed"
+  | "published"
   | "unknown";
 
 export type Severity = "high" | "medium" | "low";
@@ -26,6 +24,7 @@ export interface ComposeService {
   name: string;
   image?: string;
   ports: unknown[];
+  expose: unknown[];
   labels: Record<string, string>;
   environment: Record<string, string>;
   dependsOn: string[];
@@ -55,6 +54,7 @@ export interface ServiceAnalysis {
   localhostPorts: PortMapping[];
   isReverseProxy: boolean;
   hasReverseProxyRouting: boolean;
+  why: string;
   findings: Finding[];
   notes: string[];
 }

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -1,0 +1,5 @@
+export const CONFIGURATION_ONLY_WARNING = [
+  "ExposeMap reads local Compose configuration only.",
+  "It does not test live reachability, firewall, DNS, VPN, tunnels, cloud security groups, or vulnerabilities.",
+  "Do not paste real Compose files or secrets into public issues. Use sanitized examples only."
+].join("\n");

--- a/src/warnings.ts
+++ b/src/warnings.ts
@@ -1,5 +1,21 @@
-export const CONFIGURATION_ONLY_WARNING = [
+export const CONFIGURATION_ONLY_WARNING_LINES = [
   "ExposeMap reads local Compose configuration only.",
   "It does not test live reachability, firewall, DNS, VPN, tunnels, cloud security groups, or vulnerabilities.",
   "Do not paste real Compose files or secrets into public issues. Use sanitized examples only."
-].join("\n");
+];
+
+export const CLASSIFICATION_WARNING_LINES = [
+  "published means host-published in Compose, not internet-reachable.",
+  "internal means no host-published ports found, not impossible to reach."
+];
+
+export const STATIC_COMPOSE_LIMITATION_WARNING =
+  "Some Compose features, such as profiles, extends, include, anchors, merge keys, or variable interpolation, may require expanded Compose config for safer review.";
+
+export const CONFIGURATION_ONLY_WARNING = CONFIGURATION_ONLY_WARNING_LINES.join("\n");
+
+export const REPORT_WARNING_LINES = [
+  ...CLASSIFICATION_WARNING_LINES,
+  ...CONFIGURATION_ONLY_WARNING_LINES,
+  STATIC_COMPOSE_LIMITATION_WARNING
+];

--- a/tests/directExposure.test.ts
+++ b/tests/directExposure.test.ts
@@ -16,7 +16,7 @@ describe("direct exposure detection", () => {
     expect(hasDirectExposure(ports)).toBe(true);
   });
 
-  it("does not flag localhost-only bindings", () => {
+  it("does not flag localhost-bound ports as broad host bindings", () => {
     const ports = parsePortMappings(["127.0.0.1:5432:5432"]);
 
     expect(hasDirectExposure(ports)).toBe(false);

--- a/tests/json.test.ts
+++ b/tests/json.test.ts
@@ -45,35 +45,30 @@ services:
     expect(json.summary).toMatchObject({
       totalServices: 5,
       internal: 1,
-      localhostOnly: 1,
-      directlyExposed: 2,
-      reverseProxyExposed: 1,
-      unknown: 0,
-      totalFindings: 3,
-      high: 1,
-      medium: 0,
-      low: 2
+      published: 3,
+      unknown: 1,
+      totalFindings: 2,
+      high: 0,
+      medium: 1,
+      low: 1
     });
     expect(json.services.find((service) => service.name === "app")).toMatchObject({
-      classification: "reverse-proxy exposed",
+      classification: "unknown",
+      why: "proxy labels detected; note only in MVP",
       labels: {
         "traefik.enable": "true"
       },
-      evidence: expect.arrayContaining(["reverse proxy routing labels/env detected"])
+      evidence: expect.arrayContaining(["proxy labels detected; note only in MVP"])
     });
     expect(json.exposureMap).toContainEqual(
       expect.objectContaining({
         service: "db",
-        classification: "directly exposed",
-        entrypoints: ["internet"],
+        classification: "published",
+        entrypoints: ["host-published-in-compose"],
         evidence: ["5432:5432"]
       })
     );
-    expect(json.findings[0]).toMatchObject({
-      ruleId: "risky-direct-port",
-      severity: "high",
-      service: "db"
-    });
+    expect(json.findings.some((finding) => finding.ruleId === "risky-direct-port")).toBe(false);
     expect(json.mermaid).toContain("graph TD");
   });
 

--- a/tests/json.test.ts
+++ b/tests/json.test.ts
@@ -42,6 +42,13 @@ services:
     expect(json.tool.version).toBe(getToolVersion());
     expect(json.scannedFilePath).toBe("compose.yml");
     expect(Date.parse(json.generatedAt)).not.toBeNaN();
+    expect(json.disclaimers).toEqual(
+      expect.arrayContaining([
+        "published means host-published in Compose, not internet-reachable.",
+        "internal means no host-published ports found, not impossible to reach.",
+        "Some Compose features, such as profiles, extends, include, anchors, merge keys, or variable interpolation, may require expanded Compose config for safer review."
+      ])
+    );
     expect(json.summary).toMatchObject({
       totalServices: 5,
       internal: 1,
@@ -87,6 +94,7 @@ services:
     const parsed = JSON.parse(renderJsonReport(report));
 
     expect(parsed.tool.name).toBe("ExposeMap");
+    expect(parsed.disclaimers).toContain("published means host-published in Compose, not internet-reachable.");
     expect(parsed.summary.totalServices).toBe(1);
   });
 });

--- a/tests/localhostBindings.test.ts
+++ b/tests/localhostBindings.test.ts
@@ -3,14 +3,14 @@ import { getLocalhostBindings, hasOnlyLocalhostBindings } from "../src/rules/loc
 import { parsePortMappings } from "../src/rules/ports.js";
 
 describe("localhost binding detection", () => {
-  it("detects localhost-only services", () => {
+  it("detects localhost-bound ports", () => {
     const ports = parsePortMappings(["127.0.0.1:8080:8080", "localhost:3000:3000"]);
 
     expect(getLocalhostBindings(ports)).toHaveLength(2);
     expect(hasOnlyLocalhostBindings(ports)).toBe(true);
   });
 
-  it("does not treat broad bindings as localhost-only", () => {
+  it("does not treat broad bindings as localhost-bound only", () => {
     const ports = parsePortMappings(["127.0.0.1:8080:8080", "80:80"]);
 
     expect(hasOnlyLocalhostBindings(ports)).toBe(false);

--- a/tests/mermaid.test.ts
+++ b/tests/mermaid.test.ts
@@ -3,7 +3,7 @@ import { parseComposeContent } from "../src/parser.js";
 import { analyzeProject } from "../src/rules/serviceClassifier.js";
 
 describe("Mermaid diagram generation", () => {
-  it("renders internet, reverse proxy, routed service, and dependencies", () => {
+  it("renders Compose visibility groups and dependencies without internet reachability claims", () => {
     const project = parseComposeContent(`
 services:
   traefik:
@@ -24,8 +24,9 @@ services:
     const report = analyzeProject(project);
 
     expect(report.mermaid).toContain("graph TD");
-    expect(report.mermaid).toContain("Internet --> svc_traefik");
-    expect(report.mermaid).toContain("svc_traefik --> svc_web");
+    expect(report.mermaid).toContain("Published --> svc_traefik");
+    expect(report.mermaid).toContain("Unknown -.-> svc_web");
     expect(report.mermaid).toContain("svc_web --> svc_db");
+    expect(report.mermaid).not.toContain("Internet");
   });
 });

--- a/tests/riskyServices.test.ts
+++ b/tests/riskyServices.test.ts
@@ -3,26 +3,26 @@ import { findRiskyDirectExposure } from "../src/rules/riskyServices.js";
 import { parsePortMappings } from "../src/rules/ports.js";
 import { getBroadlyBoundPorts } from "../src/rules/directExposure.js";
 
-describe("risky direct exposure detection", () => {
-  it("flags directly exposed PostgreSQL", () => {
+describe("host-published sensitive port notes", () => {
+  it("flags host-published PostgreSQL", () => {
     const ports = getBroadlyBoundPorts(parsePortMappings(["5432:5432"]));
     const findings = findRiskyDirectExposure("db", ports);
 
     expect(findings).toHaveLength(1);
     expect(findings[0]).toMatchObject({
       severity: "high",
-      title: "PostgreSQL appears directly exposed"
+      title: "PostgreSQL has a host-published Compose port"
     });
   });
 
-  it("flags directly exposed admin ports", () => {
+  it("flags host-published admin ports", () => {
     const ports = getBroadlyBoundPorts(parsePortMappings(["8080:8080"]));
     const findings = findRiskyDirectExposure("admin", ports);
 
     expect(findings[0]?.title).toContain("Admin");
   });
 
-  it("does not flag localhost-only Redis", () => {
+  it("does not flag localhost-bound Redis", () => {
     const ports = getBroadlyBoundPorts(parsePortMappings(["127.0.0.1:6379:6379"]));
     const findings = findRiskyDirectExposure("redis", ports);
 

--- a/tests/serviceClassifier.test.ts
+++ b/tests/serviceClassifier.test.ts
@@ -3,7 +3,7 @@ import { parseComposeContent } from "../src/parser.js";
 import { analyzeProject } from "../src/rules/serviceClassifier.js";
 
 describe("service classification", () => {
-  it("classifies internal, localhost-only, directly exposed, and reverse-proxy exposed services", () => {
+  it("classifies services into MVP looks-like values only", () => {
     const project = parseComposeContent(`
 services:
   web:
@@ -21,6 +21,14 @@ services:
       traefik.http.routers.app.rule: Host(\`app.example.test\`)
   worker:
     image: worker
+  api:
+    image: api
+    expose:
+      - "3000"
+  odd:
+    image: odd
+    ports:
+      - "\${HOST_PORT}:80"
 `);
 
     const report = analyzeProject(project);
@@ -29,10 +37,20 @@ services:
     );
 
     expect(classifications).toEqual({
-      web: "directly exposed",
-      admin: "localhost-only",
-      app: "reverse-proxy exposed",
-      worker: "internal"
+      web: "published",
+      admin: "published",
+      app: "unknown",
+      worker: "internal",
+      api: "internal",
+      odd: "unknown"
     });
+
+    const admin = report.services.find((service) => service.service.name === "admin");
+    const app = report.services.find((service) => service.service.name === "app");
+    const api = report.services.find((service) => service.service.name === "api");
+
+    expect(admin?.why).toBe("ports: 127.0.0.1:8080:8080");
+    expect(app?.why).toBe("proxy labels detected; note only in MVP");
+    expect(api?.why).toBe("expose only: 3000");
   });
 });

--- a/tests/table.test.ts
+++ b/tests/table.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { parseComposeContent } from "../src/parser.js";
+import { renderTableReport } from "../src/report/table.js";
+import { analyzeProject } from "../src/rules/serviceClassifier.js";
+
+describe("table report output", () => {
+  it("renders MVP looks-like values and fixed safety copy", () => {
+    const report = analyzeProject(
+      parseComposeContent(
+        `
+services:
+  web:
+    image: nginx
+    ports:
+      - "8080:80"
+  api:
+    image: node
+    expose:
+      - "3000"
+  admin:
+    image: admin
+    ports:
+      - "127.0.0.1:8080:80"
+  proxyish:
+    image: app
+    labels:
+      traefik.enable: "true"
+  odd:
+    image: alpine
+    ports:
+      - "\${HOST_PORT}:80"
+`,
+        "compose.yml"
+      )
+    );
+
+    const output = renderTableReport(report);
+
+    expect(output).toContain("Service");
+    expect(output).toContain("Looks like");
+    expect(output).toContain("web        published");
+    expect(output).toContain("api        internal");
+    expect(output).toContain("admin      published");
+    expect(output).toContain("proxyish   unknown");
+    expect(output).toContain("odd        unknown");
+    expect(output).toContain("published means host-published in Compose, not internet-reachable.");
+    expect(output).toContain("internal means no host-published ports found, not impossible to reach.");
+    expect(output).toContain("ExposeMap reads local Compose configuration only.");
+    expect(output).toContain("Do not paste real Compose files or secrets into public issues.");
+  });
+});

--- a/tests/table.test.ts
+++ b/tests/table.test.ts
@@ -47,5 +47,8 @@ services:
     expect(output).toContain("internal means no host-published ports found, not impossible to reach.");
     expect(output).toContain("ExposeMap reads local Compose configuration only.");
     expect(output).toContain("Do not paste real Compose files or secrets into public issues.");
+    expect(output).toContain(
+      "Some Compose features, such as profiles, extends, include, anchors, merge keys, or variable interpolation, may require expanded Compose config for safer review."
+    );
   });
 });


### PR DESCRIPTION
## Summary
- switch MVP reporting to the approved published / internal / unknown looks-like model
- add fixed safety copy for host-published vs internet reachability
- add JSON disclaimers and static Compose limitation notes for CI/report consumers
- update README, CI docs, sample report, and tests

## Verification
- npm run build
- npm test
- node dist/cli.js scan examples/risky-compose.yml --format table
- node dist/cli.js scan examples/risky-compose.yml --format json | rg -n "disclaimers|published means|internal means|expanded Compose config|Compose configuration only"
- git diff --check

## Scope Boundary
This PR does not publish a release, change pricing, create external posts, contact users, or change repository visibility.