### PR TITLE
docs : add --format html example to ci-usage.md

### DIFF
--- a/docs/ci-usage.md
+++ b/docs/ci-usage.md
@@ -51,6 +51,19 @@ The JSON report includes:
 - findings
 - Mermaid diagram string
 
+## HTML Report
+
+Generate a static HTML report you can open in a browser:
+
+```bash
+node dist/cli.js scan ./docker-compose.yml --format html
+```
+The HTML report is static, local, and loads no external scripts.
+Nothing is uploaded anywhere.
+
+- Warning : Reports may contain sensitive service names,
+- Set proper artifact retention rules in your CI.
+
 ## Fail-on Thresholds
 
 `--fail-on` controls whether ExposeMap exits non-zero after a successful scan.


### PR DESCRIPTION
Closes #19 

- Added a short `--format html` example in `docs/ci-usage.md`
- Mentioned that the HTML report is static, local, and loads no external scripts
- Kept the warning that Compose files and reports may contain sensitive service names, so teams should choose artifact retention rules carefully
